### PR TITLE
Add copilot command guide and agent rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Copilot Command Guide
+
+## Bootstrap
+- `pip install -r requirements.txt`【F:README.md†L43-L53】
+
+## Build
+- **Recommended:** `python src/installers/build_installer.py`【F:README.md†L170-L174】
+- `pyinstaller --onefile --name=PhoenixKey main.py`【F:README.md†L170-L177】
+- `python -m PyInstaller --onefile --windowed --name BootForge --add-data src:src --hidden-import PyQt6.QtCore --hidden-import PyQt6.QtWidgets --hidden-import PyQt6.QtGui --hidden-import requests --hidden-import psutil --hidden-import cryptography --hidden-import yaml --hidden-import click --hidden-import colorama main.py` (use `;` instead of `:` in `--add-data` on Windows)【F:build_system/simple_build.py†L19-L36】
+
+## Test
+- `python -m pytest tests/`【F:README.md†L179-L183】
+- `python -m pytest tests/ --cov=src`【F:README.md†L183-L186】
+
+## Lint
+- No lint commands are documented in the reviewed files.
+
+## Package
+- `python build_system/build_all.py` (ensures PyInstaller is installed, builds the platform executable, and generates the USB toolkit)【F:build_system/build_all.py†L11-L47】

--- a/.github/instructions/patch-pipeline.instructions.md
+++ b/.github/instructions/patch-pipeline.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "bootable_usb/BootForge/src/core/patch_pipeline.py"
+---
+
+# Patch Pipeline Rules
+
+- Keep patch stages deterministic (prepare ➜ apply ➜ verify ➜ cleanup) and document any ordering changes in code comments.
+- Surface actionable errors that name the failing patch step and target device; avoid silent fallbacks.
+- Guard platform-specific operations and never assume write access without explicit checks.
+- Keep logging concise but include patch identifiers and device paths for traceability.
+- Add or update targeted tests in `bootable_usb/BootForge/tests/` when changing pipeline flow or validation logic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Agent Instructions
+
+- Never edit generated/output folders.
+- Keep command documentation in `.github/copilot-instructions.md` aligned with the latest verified build/test steps.
+- Prefer documenting commands with exact invocations copied from source docs or scripts; avoid guessing.

--- a/bootable_usb/BootForge/AGENTS.md
+++ b/bootable_usb/BootForge/AGENTS.md
@@ -1,0 +1,5 @@
+# BootForge Agent Instructions
+
+- Never edit generated/output folders.
+- Keep BootForge build and packaging commands in sync with `build_system` scripts when updating docs or tooling.
+- Preserve platform guards and device-safety checks when modifying BootForge code.


### PR DESCRIPTION
## Summary
- add repository and BootForge agent instructions emphasizing generated/output folders
- capture verified bootstrap, build, test, and packaging commands in the copilot guide
- document patch pipeline editing rules for the BootForge core module

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d0b49bff88327bc133422195dab64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added command reference guide and workflow instructions for contributors.
  * Added patch pipeline guidelines and repository maintenance instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->