### PR TITLE
Phase 4C-2: Contract CLI + Dashboard Read-Only Contract Preview

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -130,7 +130,12 @@ export default function App() {
   const [mockWriterError, setMockWriterError] = useState(null);
   const [mockFailAtChunk, setMockFailAtChunk] = useState('');
   const [mockCancelAtChunk, setMockCancelAtChunk] = useState('');
-  
+
+  // Writer Safety Contract Preview States (Phase 4C-2)
+  const [contractData, setContractData] = useState(null);
+  const [isPreviewingContract, setIsPreviewingContract] = useState(false);
+  const [contractError, setContractError] = useState(null);
+
   // Selection check states
   const [includeOclp, setIncludeOclp] = useState(true);
   const [includeBootcamp, setIncludeBootcamp] = useState(true);
@@ -657,6 +662,35 @@ ${warningsStr}
   const handleCreate = () => {
     addLog('warning', 'Creation is disabled in Phase 2A. Image inspection is read-only; USB write, format, partition, and burn operations remain locked.');
     setProgress(0);
+  };
+
+  // ----- Writer Safety Contract Preview (Phase 4C-2) -----
+  // Calls GET /api/write/contract — read-only, no drive mutation.
+  // Never writes, formats, partitions, mounts, unmounts, or accesses any drive.
+  const fetchContractPreview = async () => {
+    setIsPreviewingContract(true);
+    setContractError(null);
+    setContractData(null);
+    try {
+      const params = new URLSearchParams();
+      if (selectedDrive) params.set('drive', selectedDrive);
+      if (imagePath)     params.set('image', imagePath);
+      if (auditData?.validation_status === 'passed') params.set('auditPassed', 'true');
+      if (mockWriterData?.status === 'completed')    params.set('simulationPassed', 'true');
+      const response = await fetch(`/api/write/contract?${params.toString()}`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      const data = await response.json();
+      if (!data || data.schema !== 'bootforge.writer_safety_contract.v1') {
+        throw new Error('Unexpected response schema from contract preview endpoint');
+      }
+      setContractData(data);
+    } catch (err) {
+      setContractError(err.message || 'Contract preview request failed');
+    } finally {
+      setIsPreviewingContract(false);
+    }
   };
 
   // SVG calculations for progress ring
@@ -1631,6 +1665,184 @@ ${warningsStr}
               </div>
             </div>
           )}
+
+          {/* --------------------------------------------------------- */}
+          {/* Writer Safety Contract Preview Panel (Phase 4C-2)          */}
+          {/* Read-only. No writes. No formatting. No drive mutation.    */}
+          {/* --------------------------------------------------------- */}
+          <div
+            id="writer-safety-contract-preview-panel"
+            className="glass-panel animate-fade-in"
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '16px',
+              border: '1px solid rgba(139, 92, 246, 0.35)',
+              background: 'rgba(139, 92, 246, 0.04)',
+            }}
+          >
+            {/* Panel Header */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', borderBottom: '1px solid rgba(139,92,246,0.2)', paddingBottom: '10px' }}>
+              <h2 style={{ fontSize: '1.05rem', display: 'flex', alignItems: 'center', gap: '8px', margin: 0 }}>
+                <ShieldCheck size={18} style={{ color: '#8b5cf6' }} />
+                <span style={{ fontFamily: 'var(--font-tech)', letterSpacing: '0.04em' }}>Writer Safety Contract Preview</span>
+              </h2>
+              <button
+                id="btn-preview-writer-safety-contract"
+                className="btn-primary"
+                onClick={fetchContractPreview}
+                disabled={isPreviewingContract}
+                style={{
+                  background: 'linear-gradient(135deg, #6d28d9 0%, #8b5cf6 100%)',
+                  padding: '8px 16px',
+                  fontSize: '0.85rem',
+                  opacity: isPreviewingContract ? 0.6 : 1,
+                  cursor: isPreviewingContract ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {isPreviewingContract
+                  ? <><RefreshCw size={14} className="spin-anim" /> Previewing…</>
+                  : <><ShieldCheck size={14} /> Preview Writer Safety Contract</>}
+              </button>
+            </div>
+
+            {/* Safety Copy — always visible */}
+            <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', display: 'flex', alignItems: 'flex-start', gap: '6px', background: 'rgba(0,0,0,0.15)', padding: '8px 10px', borderRadius: '6px', lineHeight: 1.5 }}>
+              <ShieldAlert size={13} style={{ color: '#8b5cf6', flexShrink: 0, marginTop: '1px' }} />
+              <span>Read-only safety contract preview. No USB write, format, partition, mount, unmount, raw disk access, or destructive operation is available.</span>
+            </div>
+
+            {/* Loading state */}
+            {isPreviewingContract && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '12px', color: 'var(--text-muted)', fontSize: '0.88rem' }}>
+                <RefreshCw size={16} className="spin-anim" style={{ color: '#8b5cf6' }} />
+                <span>Fetching safety contract from backend…</span>
+              </div>
+            )}
+
+            {/* Error state */}
+            {contractError && (
+              <div style={{ padding: '12px', background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: '8px', color: '#f87171', fontSize: '0.85rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <ShieldAlert size={16} />
+                <span>{contractError}</span>
+              </div>
+            )}
+
+            {/* Contract data */}
+            {contractData && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+
+                {/* Schema + IDs row */}
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                  <span style={{ fontFamily: 'var(--font-tech)', fontSize: '0.75rem', padding: '3px 10px', borderRadius: '20px', background: 'rgba(139,92,246,0.15)', color: '#a78bfa', border: '1px solid rgba(139,92,246,0.3)' }}>
+                    {contractData.schema}
+                  </span>
+                  <span style={{ fontFamily: 'var(--font-tech)', fontSize: '0.72rem', padding: '3px 10px', borderRadius: '20px', background: 'rgba(0,0,0,0.2)', color: 'var(--text-muted)', border: '1px solid var(--border-glass)' }}>
+                    Phase {contractData.phase}
+                  </span>
+                  <span style={{
+                    fontFamily: 'var(--font-tech)', fontSize: '0.75rem', padding: '3px 10px', borderRadius: '20px', border: '1px solid rgba(239,68,68,0.35)',
+                    background: contractData.blocked ? 'rgba(239,68,68,0.12)' : 'rgba(16,185,129,0.12)',
+                    color: contractData.blocked ? '#f87171' : '#10b981',
+                  }}>
+                    {contractData.blocked ? '⛔ BLOCKED' : '✓ UNBLOCKED'}
+                  </span>
+                </div>
+
+                {/* Immutable safety values */}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+                  {[{
+                    label: 'real_writer_implemented',
+                    value: String(contractData.real_writer_implemented),
+                    ok: contractData.real_writer_implemented === false,
+                  }, {
+                    label: 'destructive_operations_enabled',
+                    value: String(contractData.destructive_operations_enabled),
+                    ok: contractData.destructive_operations_enabled === false,
+                  }].map(({ label, value, ok }) => (
+                    <div key={label} style={{ background: 'rgba(0,0,0,0.25)', borderRadius: '8px', padding: '10px 12px', border: `1px solid ${ok ? 'rgba(16,185,129,0.25)' : 'rgba(239,68,68,0.35)'}`, display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                      <span style={{ fontSize: '0.72rem', color: 'var(--text-muted)', fontFamily: 'var(--font-tech)' }}>{label}</span>
+                      <span style={{ fontSize: '0.95rem', fontWeight: 700, color: ok ? '#10b981' : '#f87171', fontFamily: 'var(--font-tech)' }}>{value}</span>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Gate results table */}
+                {contractData.gate_results && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <h3 style={{ fontSize: '0.82rem', color: 'var(--text-muted)', margin: 0, fontFamily: 'var(--font-tech)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Gate Results</h3>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                      {(contractData.required_gates || Object.keys(contractData.gate_results)).map((gate) => {
+                        const passed = contractData.gate_results[gate];
+                        return (
+                          <div key={gate} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 10px', background: 'rgba(0,0,0,0.2)', borderRadius: '6px', border: '1px solid var(--border-glass)', fontSize: '0.8rem' }}>
+                            <span style={{ color: passed ? '#fff' : 'var(--text-muted)', fontFamily: 'var(--font-tech)' }}>{gate}</span>
+                            <span style={{ fontSize: '0.72rem', fontWeight: 700, color: passed ? '#10b981' : '#94a3b8', fontFamily: 'var(--font-tech)' }}>{passed ? '✓ PASS' : '— PENDING'}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Identity hashes */}
+                {(contractData.device_identity?.identity_hash || contractData.image_identity?.identity_hash) && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <h3 style={{ fontSize: '0.82rem', color: 'var(--text-muted)', margin: 0, fontFamily: 'var(--font-tech)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Identity Hashes</h3>
+                    {contractData.device_identity?.identity_hash && (
+                      <div style={{ fontFamily: 'var(--font-tech)', fontSize: '0.72rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.25)', padding: '8px 10px', borderRadius: '6px', wordBreak: 'break-all' }}>
+                        <span style={{ color: '#a78bfa', marginRight: '8px' }}>device:</span>{contractData.device_identity.identity_hash}
+                      </div>
+                    )}
+                    {contractData.image_identity?.identity_hash && (
+                      <div style={{ fontFamily: 'var(--font-tech)', fontSize: '0.72rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.25)', padding: '8px 10px', borderRadius: '6px', wordBreak: 'break-all' }}>
+                        <span style={{ color: '#a78bfa', marginRight: '8px' }}>image:</span>{contractData.image_identity.identity_hash}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Block reasons */}
+                {contractData.block_reasons?.length > 0 && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <h3 style={{ fontSize: '0.82rem', color: '#f87171', margin: 0, fontFamily: 'var(--font-tech)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Block Reasons</h3>
+                    {contractData.block_reasons.map((r, i) => (
+                      <div key={i} style={{ fontSize: '0.8rem', color: '#fca5a5', paddingLeft: '14px', display: 'flex', gap: '6px', alignItems: 'flex-start', lineHeight: 1.4 }}>
+                        <span style={{ color: '#ef4444', flexShrink: 0 }}>•</span>
+                        <span>{r}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Warnings */}
+                {contractData.warnings?.length > 0 && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    <h3 style={{ fontSize: '0.82rem', color: '#fbbf24', margin: 0, fontFamily: 'var(--font-tech)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Warnings</h3>
+                    {contractData.warnings.map((w, i) => (
+                      <div key={i} style={{ fontSize: '0.78rem', color: '#fcd34d', paddingLeft: '14px', display: 'flex', gap: '6px', alignItems: 'flex-start', lineHeight: 1.4 }}>
+                        <span style={{ color: '#f59e0b', flexShrink: 0 }}>⚠</span>
+                        <span>{w}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Next required action */}
+                {contractData.next_required_action && (
+                  <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.2)', padding: '8px 12px', borderRadius: '6px', border: '1px solid var(--border-glass)', display: 'flex', gap: '8px', alignItems: 'center' }}>
+                    <ShieldAlert size={13} style={{ color: '#8b5cf6', flexShrink: 0 }} />
+                    <span><strong style={{ color: '#c4b5fd' }}>Next action:</strong> {contractData.next_required_action}</span>
+                  </div>
+                )}
+
+                {/* Contract ID + timestamp */}
+                <div style={{ fontSize: '0.72rem', color: 'rgba(148,163,184,0.5)', fontFamily: 'var(--font-tech)', borderTop: '1px solid rgba(255,255,255,0.04)', paddingTop: '8px' }}>
+                  {contractData.contract_id} · {contractData.created_at}
+                </div>
+              </div>
+            )}
+          </div>
 
           {/* Terminal Console */}
           <div className="terminal-container">

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -334,6 +334,37 @@ function usbCreatorBridgePlugin() {
           return
         }
 
+        if (requestUrl.pathname === '/api/write/contract') {
+          if (req.method !== 'GET') {
+            sendJson(res, 405, { error: 'Method not allowed' })
+            return
+          }
+
+          const drivePath = requestUrl.searchParams.get('drive')
+          const imagePath = requestUrl.searchParams.get('image')
+          const auditPassed = requestUrl.searchParams.get('auditPassed') === 'true'
+          const simulationPassed = requestUrl.searchParams.get('simulationPassed') === 'true'
+
+          const args = ['--validate-writer-contract']
+          if (drivePath) args.push('--target-drive', drivePath)
+          if (imagePath) args.push('--image', imagePath)
+          if (auditPassed) args.push('--audit-passed')
+          if (simulationPassed) args.push('--simulation-passed')
+
+          runUsbCreator(
+            args,
+            {
+              schema: 'bootforge.writer_safety_contract.v1',
+              real_writer_implemented: false,
+              destructive_operations_enabled: false,
+              blocked: true,
+              block_reasons: ['contract preview endpoint error — safe fallback'],
+            },
+            res
+          )
+          return
+        }
+
         next()
       })
     },

--- a/docs/evidence/phase4c2-contract-cli-dashboard-preview.md
+++ b/docs/evidence/phase4c2-contract-cli-dashboard-preview.md
@@ -1,0 +1,252 @@
+# Phase 4C-2: Contract CLI + Dashboard Read-Only Contract Preview
+
+**Branch:** `phase4c2/contract-cli-dashboard-preview`  
+**Base commit:** `b25ee1c6` (Merge PR #112 — Phase 4C-1)  
+**Date:** 2026-06-21  
+**Tag:** `phase4c2-contract-cli-dashboard-preview-lock`
+
+---
+
+## 1. Phase Purpose
+
+Phase 4C-2 exposes the writer safety contract (`bootforge.writer_safety_contract.v1`) for
+read-only visibility through the CLI and the dashboard UI. It does **not** expand the
+contract's power: the cage is shown, the tiger gets no door handle.
+
+No real writer is introduced. No destructive operations exist.
+`real_writer_implemented` remains `false`. `destructive_operations_enabled` remains `false`.
+
+---
+
+## 2. Files Changed
+
+| File | Type | Change |
+|---|---|---|
+| `writer_safety_contract.py` | MODIFIED | Added `build_contract_preview_payload()` bridge function; updated `_cli_validate_writer_contract()` to consume full preview args |
+| `usb_creator.py` | MODIFIED | Wired `--validate-writer-contract`, `--audit-passed`, `--simulation-passed`, `--typed-confirmation`, `--destructive-acknowledgement` CLI flags |
+| `dashboard/vite.config.js` | MODIFIED | Added `GET /api/write/contract` bridge route |
+| `dashboard/src/App.jsx` | MODIFIED | Added `contractData` state, `fetchContractPreview()` async function, and Writer Safety Contract Preview panel |
+| `tests/test_writer_safety_contract_preview.py` | NEW | 10 test objectives, 17 test methods |
+| `docs/evidence/phase4c2-contract-cli-dashboard-preview.md` | NEW | This evidence document |
+
+No existing test files were modified. `usb_creator.py` changes are additive only.
+
+---
+
+## 3. CLI Behavior
+
+### New flag: `--validate-writer-contract`
+
+```bash
+python usb_creator.py --validate-writer-contract
+python usb_creator.py --validate-writer-contract --target-drive E:\ --image ubuntu.iso
+python usb_creator.py --validate-writer-contract --target-drive E:\ --image ubuntu.iso --audit-passed --simulation-passed
+```
+
+**What it does:**
+- Delegates immediately to `writer_safety_contract._cli_validate_writer_contract(args)`
+- Calls `build_contract_preview_payload()` with the supplied args
+- Prints the full contract JSON to stdout
+- Returns exit code 0 always (blocked contracts are not errors)
+
+**What it does NOT do:**
+- Does not open, read, write, mount, unmount, or query any drive
+- Does not call diskpart, dd, WriteFile, or any raw-device API
+- Does not perform any destructive action
+- Does not change any system state
+
+### New companion flags
+
+| Flag | Type | Purpose |
+|---|---|---|
+| `--audit-passed` | boolean | Reports audit gate as passed in the preview |
+| `--simulation-passed` | boolean | Reports simulation gate as passed in the preview |
+| `--typed-confirmation` | string | Future gate display only — no effect on blocking |
+| `--destructive-acknowledgement` | string | Future gate display only — no effect on blocking |
+
+---
+
+## 4. Dashboard API Endpoint
+
+### `GET /api/write/contract`
+
+Implemented in `dashboard/vite.config.js` as a bridge route, following the same
+pattern as all existing bridge routes.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `drive` | string | Candidate target drive path |
+| `image` | string | Candidate image file path |
+| `auditPassed` | `"true"` / omit | Whether audit gate should be reported as passed |
+| `simulationPassed` | `"true"` / omit | Whether simulation gate should be reported as passed |
+
+**Response schema:** `bootforge.writer_safety_contract.v1`
+
+**Invariants:**
+- `real_writer_implemented: false` — always
+- `destructive_operations_enabled: false` — always
+- `blocked: true` — always (Phase 4C-2 lock)
+- On any error: safe blocked fallback payload is returned, not an unhandled exception
+
+**What the endpoint does NOT do:**
+- Does not write, format, partition, mount, or unmount any drive
+- Does not call diskpart, dd, or any raw-device API
+- Does not expose any write-enabling path
+
+---
+
+## 5. Dashboard UI Panel
+
+### Panel title: **Writer Safety Contract Preview**
+
+Location: Below the Mock Writer Simulator panel, above the terminal console.
+
+**Button:** `Preview Writer Safety Contract` (id: `btn-preview-writer-safety-contract`)
+
+**Panel displays:**
+- Schema badge (`bootforge.writer_safety_contract.v1`)
+- Phase badge
+- Blocked status pill (⛔ BLOCKED / ✓ UNBLOCKED)
+- `real_writer_implemented: false` — green card
+- `destructive_operations_enabled: false` — green card
+- Gate results table (all 11 required gates with PASS / PENDING status)
+- Identity hashes (device + image, if present)
+- Block reasons list
+- Warnings list
+- Next required action
+- Contract ID + timestamp
+
+**Required safety copy (always visible):**
+> "Read-only safety contract preview. No USB write, format, partition, mount,
+> unmount, raw disk access, or destructive operation is available."
+
+**Forbidden labels confirmed absent:**
+- Write USB ✗ not present
+- Burn USB ✗ not present
+- Flash USB ✗ not present
+- Start Write ✗ not present
+- Format USB ✗ not present
+- Erase Drive ✗ not present
+- Arm Writer ✗ not present
+- Execute Write ✗ not present
+- Destructive Write ✗ not present
+- Write Now ✗ not present
+
+---
+
+## 6. Safety Statement
+
+```text
+real_writer_implemented        = false  (hard-coded, immutable)
+destructive_operations_enabled = false  (hard-coded, immutable)
+blocked                        = true   (always — at minimum by the 4C lock)
+
+No write to any drive.
+No format.
+No partition changes.
+No mount or unmount operations.
+No raw disk access.
+No diskpart.
+No dd.
+No WriteFile / CreateFile on block devices.
+No subprocess calls to disk utilities.
+No real write button.
+No arm writer button.
+```
+
+The `build_contract_preview_payload()` function builds identity structures from
+path strings only. It does not stat, open, or read any file unless checking whether
+an image path exists (size_bytes field) — and even then it only calls `Path.stat()`,
+not any write or device API.
+
+---
+
+## 7. Test Results
+
+**Command:**
+```bat
+python -m unittest tests/test_usb_creator.py tests/test_image_inspection.py ^
+  tests/test_drive_safety.py tests/test_write_plan.py tests/test_plan_audit.py ^
+  tests/test_plan_export.py tests/test_mock_writer.py ^
+  tests/test_writer_safety_contract.py tests/test_writer_safety_contract_preview.py
+```
+
+**Result:**
+```text
+Ran 91 tests in 1.382s
+
+OK
+```
+
+**Dashboard build:**
+```text
+vite v8.0.14 building for production...
+✓ 1738 modules transformed.
+dist/index.html       0.67 kB │ gzip:  0.41 kB
+dist/assets/*.css     7.78 kB │ gzip:  2.19 kB
+dist/assets/*.js    252.00 kB │ gzip: 73.19 kB
+✓ built in 2.49s
+```
+
+### Test objectives satisfied
+
+| # | Objective | Status |
+|---|---|---|
+| 1 | Preview returns schema `bootforge.writer_safety_contract.v1` | ✅ |
+| 2 | `real_writer_implemented` remains `false` | ✅ |
+| 3 | `destructive_operations_enabled` remains `false` | ✅ |
+| 4 | Preview with missing drive is blocked | ✅ |
+| 5 | Preview with missing image is blocked | ✅ |
+| 6 | Fully valid mock preview still does not enable writing | ✅ |
+| 7 | Payload is JSON serializable (round-trip verified) | ✅ |
+| 8 | Forbidden destructive labels not in executable Python source (AST-verified) | ✅ |
+| 9 | CLI preview does not require or perform destructive actions | ✅ |
+| 10 | Repeated preview with same inputs is deterministic | ✅ |
+
+---
+
+## 8. Explicit Safety Declarations
+
+### No real writer exists
+
+> Neither `writer_safety_contract.py`, `usb_creator.py`, `vite.config.js`,
+> nor `App.jsx` contains any code that opens a device handle, calls `WriteFile`,
+> invokes `diskpart` or `dd`, accesses `/dev/` paths, or performs any byte-level
+> write to any block device. All four files build, fetch, and display JSON payloads only.
+
+### Destructive operations remain disabled
+
+> `destructive_operations_enabled` is hard-coded to `False` inside
+> `build_writer_safety_contract()` and is not a parameter, not a keyword argument,
+> and not overridable from the CLI or the dashboard API.
+
+### Forbidden capabilities still absent
+
+- USB writing: **absent**
+- Drive formatting: **absent**
+- Partition editing: **absent**
+- Mount automation: **absent**
+- Unmount automation: **absent**
+- Raw disk access: **absent**
+- diskpart invocation: **absent**
+- dd invocation: **absent**
+- Bootloader writing: **absent**
+- Real write button: **absent**
+- Arm writer button: **absent**
+
+---
+
+## 9. Phase 4C-2 Exit Criteria Status
+
+| EC | Criterion | Status |
+|---|---|---|
+| EC1 | Contract preview available through safe CLI path | ✅ Done |
+| EC2 | Dashboard API endpoint returns blocked contract | ✅ Done |
+| EC3 | Dashboard UI shows contract read-only panel | ✅ Done |
+| EC4 | Required safety copy present in UI | ✅ Done |
+| EC5 | Forbidden UI labels absent | ✅ Confirmed |
+| EC6 | 91 tests passing, 0 regressions | ✅ Confirmed |
+| EC7 | Dashboard build clean | ✅ Confirmed |
+| EC8 | No real writer introduced | ✅ Confirmed |

--- a/tests/test_writer_safety_contract_preview.py
+++ b/tests/test_writer_safety_contract_preview.py
@@ -1,0 +1,389 @@
+"""
+tests/test_writer_safety_contract_preview.py
+PhoenixCore / BootForge USB Creator
+Phase 4C-2: Contract CLI + Dashboard Preview Tests
+
+Tests prove that:
+  1.  Contract preview returns schema bootforge.writer_safety_contract.v1
+  2.  real_writer_implemented remains false in preview
+  3.  destructive_operations_enabled remains false in preview
+  4.  Preview with missing drive is blocked
+  5.  Preview with missing image is blocked
+  6.  Preview with fully valid mock data still does not enable writing
+  7.  Payload is JSON serializable
+  8.  Forbidden destructive words/commands are not in executable Python source
+  9.  CLI preview does not require or perform destructive actions
+  10. Repeated preview with same inputs is deterministic
+
+No test in this file writes, formats, partitions, mounts, unmounts,
+or accesses any real drive or device.
+"""
+
+import ast
+import json
+import os
+import unittest
+
+from writer_safety_contract import (
+    SCHEMA,
+    REQUIRED_GATES,
+    build_contract_preview_payload,
+)
+
+# ---------------------------------------------------------------------------
+# Forbidden label strings that must not appear in executable code
+# (not in comments, not in docstrings — checked via AST string literals)
+# ---------------------------------------------------------------------------
+FORBIDDEN_LABELS = [
+    "Write USB",
+    "Burn USB",
+    "Flash USB",
+    "Start Write",
+    "Format USB",
+    "Erase Drive",
+    "Arm Writer",
+    "Execute Write",
+    "Destructive Write",
+    "Write Now",
+]
+
+# ---------------------------------------------------------------------------
+# Forbidden Python function/subprocess calls that would be destructive
+# ---------------------------------------------------------------------------
+FORBIDDEN_EXEC_CALLS = [
+    "diskpart",
+    "dd if=",
+    "dd of=",
+    "WriteFile(",
+    "CreateFile(",
+    "DeviceIoControl(",
+    "format ",
+    "mkfs.",
+]
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _full_preview(**kwargs):
+    """Build a preview with all non-destructive gates maximally satisfied."""
+    return build_contract_preview_payload(
+        target_drive=kwargs.get("target_drive", "E:\\"),
+        image=kwargs.get("image", "C:\\Users\\Bobby\\Downloads\\ubuntu.iso"),
+        audit_passed=kwargs.get("audit_passed", True),
+        simulation_passed=kwargs.get("simulation_passed", True),
+        typed_confirmation=kwargs.get("typed_confirmation", "I UNDERSTAND"),
+        destructive_acknowledgement=kwargs.get(
+            "destructive_acknowledgement", "I ACCEPT"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContractPreviewSchema(unittest.TestCase):
+    """Test 1 — schema is bootforge.writer_safety_contract.v1."""
+
+    def test_01_preview_schema_is_correct(self):
+        """Test 1: Contract preview must return the correct schema string."""
+        payload = _full_preview()
+        self.assertEqual(payload["schema"], "bootforge.writer_safety_contract.v1")
+        self.assertEqual(payload["schema"], SCHEMA)
+
+
+class TestContractPreviewSafetyValues(unittest.TestCase):
+    """Tests 2–3 — immutable safety flags remain False in preview."""
+
+    def test_02_real_writer_implemented_remains_false(self):
+        """Test 2: real_writer_implemented must always be False in preview."""
+        payload = _full_preview()
+        self.assertIs(payload["real_writer_implemented"], False)
+
+    def test_03_destructive_operations_enabled_remains_false(self):
+        """Test 3: destructive_operations_enabled must always be False in preview."""
+        payload = _full_preview()
+        self.assertIs(payload["destructive_operations_enabled"], False)
+
+
+class TestContractPreviewBlocking(unittest.TestCase):
+    """Tests 4–5 — missing drive or image blocks the preview."""
+
+    def test_04_missing_drive_is_blocked(self):
+        """Test 4: Preview with no target drive must be blocked."""
+        payload = build_contract_preview_payload(
+            target_drive=None,
+            image="ubuntu.iso",
+        )
+        self.assertTrue(payload["blocked"])
+        reasons = " ".join(payload["block_reasons"])
+        self.assertIn("target_drive", reasons)
+
+    def test_04b_whitespace_drive_is_blocked(self):
+        """Test 4b: Preview with whitespace-only drive must also be blocked."""
+        payload = build_contract_preview_payload(
+            target_drive="   ",
+            image="ubuntu.iso",
+        )
+        self.assertTrue(payload["blocked"])
+
+    def test_05_missing_image_is_blocked(self):
+        """Test 5: Preview with no image must be blocked."""
+        payload = build_contract_preview_payload(
+            target_drive="E:\\",
+            image=None,
+        )
+        self.assertTrue(payload["blocked"])
+        reasons = " ".join(payload["block_reasons"])
+        self.assertIn("image", reasons)
+
+    def test_05b_whitespace_image_is_blocked(self):
+        """Test 5b: Preview with whitespace-only image must also be blocked."""
+        payload = build_contract_preview_payload(
+            target_drive="E:\\",
+            image="   ",
+        )
+        self.assertTrue(payload["blocked"])
+
+
+class TestContractPreviewFullyValidStillBlocked(unittest.TestCase):
+    """Test 6 — fully populated preview still does not enable writing."""
+
+    def test_06_fully_valid_preview_still_does_not_enable_writing(self):
+        """
+        Test 6: Even with drive, image, audit_passed, simulation_passed,
+        typed_confirmation, and destructive_acknowledgement all present,
+        the contract preview is still blocked and real writing remains off.
+        """
+        payload = _full_preview()
+
+        # Always blocked because real_writer_implemented is False.
+        self.assertTrue(payload["blocked"])
+
+        # Safety flags immutable.
+        self.assertIs(payload["real_writer_implemented"], False)
+        self.assertIs(payload["destructive_operations_enabled"], False)
+
+        # The permanent Phase lock must appear in block_reasons.
+        reasons_combined = " ".join(payload["block_reasons"])
+        self.assertIn("real_writer_implemented is false", reasons_combined)
+
+    def test_06b_all_required_gates_present(self):
+        """Test 6b: All required gate names must appear in gate_results."""
+        payload = _full_preview()
+        for gate in REQUIRED_GATES:
+            self.assertIn(
+                gate,
+                payload["gate_results"],
+                msg=f"Gate '{gate}' missing from preview gate_results",
+            )
+
+
+class TestContractPreviewSerialization(unittest.TestCase):
+    """Test 7 — payload is JSON serializable."""
+
+    def test_07_payload_is_json_serializable(self):
+        """Test 7: Contract preview payload must round-trip through JSON."""
+        payload = _full_preview()
+        try:
+            serialized = json.dumps(payload)
+        except (TypeError, ValueError) as exc:
+            self.fail(f"Preview payload is not JSON serializable: {exc}")
+        reloaded = json.loads(serialized)
+        self.assertEqual(reloaded["schema"], SCHEMA)
+        self.assertIs(reloaded["real_writer_implemented"], False)
+        self.assertIs(reloaded["destructive_operations_enabled"], False)
+
+    def test_07b_empty_preview_is_json_serializable(self):
+        """Test 7b: All-None preview must also be JSON serializable."""
+        payload = build_contract_preview_payload()
+        serialized = json.dumps(payload)
+        reloaded = json.loads(serialized)
+        self.assertTrue(reloaded["blocked"])
+
+
+class TestForbiddenDestructiveWords(unittest.TestCase):
+    """Test 8 — forbidden destructive labels not in executable Python source."""
+
+    def _collect_string_literals(self, source_path: str) -> list[str]:
+        """
+        Parse a Python file with AST and collect all string literal values.
+        This catches strings in code but NOT comments.
+        """
+        with open(source_path, encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=source_path)
+        strings = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                strings.append(node.value)
+        return strings
+
+    def test_08_forbidden_labels_not_in_writer_safety_contract_py(self):
+        """
+        Test 8a: Forbidden destructive UI labels must not appear as
+        string literals in writer_safety_contract.py.
+        """
+        source = os.path.join(REPO_ROOT, "writer_safety_contract.py")
+        strings = self._collect_string_literals(source)
+        for forbidden in FORBIDDEN_LABELS:
+            for s in strings:
+                self.assertNotIn(
+                    forbidden.lower(),
+                    s.lower(),
+                    msg=f"Forbidden label '{forbidden}' found in writer_safety_contract.py",
+                )
+
+    def test_08b_forbidden_labels_not_in_usb_creator_py_new_code(self):
+        """
+        Test 8b: Forbidden destructive UI labels must not appear as
+        string literals in usb_creator.py.
+        """
+        source = os.path.join(REPO_ROOT, "usb_creator.py")
+        strings = self._collect_string_literals(source)
+        for forbidden in FORBIDDEN_LABELS:
+            for s in strings:
+                self.assertNotIn(
+                    forbidden.lower(),
+                    s.lower(),
+                    msg=f"Forbidden label '{forbidden}' found in usb_creator.py",
+                )
+
+    def test_08c_forbidden_exec_calls_not_invoked_in_writer_safety_contract(self):
+        """
+        Test 8c: No destructive subprocess calls must be made from
+        writer_safety_contract.py. AST Call node inspection only;
+        docstrings listing what the code does NOT do are excluded.
+        """
+        source_path = os.path.join(REPO_ROOT, "writer_safety_contract.py")
+        with open(source_path, encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=source_path)
+        forbidden_pairs = {
+            ("subprocess", "run"),
+            ("subprocess", "call"),
+            ("subprocess", "Popen"),
+            ("os", "system"),
+        }
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                pair = (func.value.id, func.attr)
+                if pair in forbidden_pairs:
+                    ln = getattr(node, 'lineno', '?')
+                    self.fail(
+                        "Forbidden invocation found: "
+                        + func.value.id + "." + func.attr
+                        + "() in writer_safety_contract.py line " + str(ln)
+                    )
+
+
+class TestContractPreviewNonDestructiveCLI(unittest.TestCase):
+    """Test 9 — contract preview does not require or perform destructive actions."""
+
+    def test_09_preview_with_no_args_does_not_crash(self):
+        """
+        Test 9a: build_contract_preview_payload() with all None args must
+        return a safe blocked payload without raising any exception.
+        It must not attempt to open, read, write, or query any drive.
+        """
+        try:
+            payload = build_contract_preview_payload()
+        except Exception as exc:
+            self.fail(
+                f"build_contract_preview_payload() raised an exception with no args: {exc}"
+            )
+        self.assertTrue(payload["blocked"])
+        self.assertIs(payload["real_writer_implemented"], False)
+        self.assertIs(payload["destructive_operations_enabled"], False)
+
+    def test_09b_preview_with_nonexistent_paths_does_not_crash(self):
+        """
+        Test 9b: Preview with paths to nonexistent files must return a
+        blocked payload, not raise an exception.
+        The function must never attempt to read/write a disk.
+        """
+        payload = build_contract_preview_payload(
+            target_drive="Z:\\nonexistent-drive\\",
+            image="C:\\nonexistent\\path\\image.iso",
+        )
+        self.assertIsInstance(payload, dict)
+        self.assertTrue(payload["blocked"])
+        self.assertIs(payload["real_writer_implemented"], False)
+
+    def test_09c_preview_schema_field_always_correct(self):
+        """Test 9c: Schema field must always equal the module constant."""
+        for args in [
+            {},
+            {"target_drive": "E:\\"},
+            {"image": "ubuntu.iso"},
+            {"target_drive": "E:\\", "image": "ubuntu.iso"},
+        ]:
+            payload = build_contract_preview_payload(**args)
+            self.assertEqual(payload["schema"], SCHEMA)
+
+
+class TestContractPreviewDeterminism(unittest.TestCase):
+    """Test 10 — repeated preview with same inputs is deterministic."""
+
+    def test_10_deterministic_for_same_inputs(self):
+        """
+        Test 10: Two calls to build_contract_preview_payload() with identical
+        inputs must produce identical block_reasons (sorted), gate_results,
+        schema, safety flags, and blocked state.
+        contract_id and created_at are allowed to differ.
+        """
+        kwargs = dict(
+            target_drive="E:\\",
+            image="ubuntu.iso",
+            audit_passed=True,
+            simulation_passed=True,
+            typed_confirmation="I UNDERSTAND",
+            destructive_acknowledgement="I ACCEPT",
+        )
+        p1 = build_contract_preview_payload(**kwargs)
+        p2 = build_contract_preview_payload(**kwargs)
+
+        self.assertEqual(p1["schema"], p2["schema"])
+        self.assertEqual(p1["real_writer_implemented"], p2["real_writer_implemented"])
+        self.assertEqual(
+            p1["destructive_operations_enabled"], p2["destructive_operations_enabled"]
+        )
+        self.assertEqual(p1["blocked"], p2["blocked"])
+        self.assertEqual(sorted(p1["block_reasons"]), sorted(p2["block_reasons"]))
+        self.assertEqual(p1["gate_results"], p2["gate_results"])
+        self.assertEqual(p1["required_gates"], p2["required_gates"])
+        self.assertEqual(p1["next_required_action"], p2["next_required_action"])
+
+    def test_10b_different_inputs_produce_different_gate_results(self):
+        """Test 10b: audit_passed=True vs False must produce different gate_results."""
+        p_with = build_contract_preview_payload(
+            target_drive="E:\\", image="ubuntu.iso", audit_passed=True
+        )
+        p_without = build_contract_preview_payload(
+            target_drive="E:\\", image="ubuntu.iso", audit_passed=False
+        )
+        self.assertNotEqual(
+            p_with["gate_results"]["audit_passed"],
+            p_without["gate_results"]["audit_passed"],
+        )
+
+    def test_10c_next_required_action_reflects_state(self):
+        """
+        Test 10c: next_required_action must differ between a fully-stated
+        preview and a no-drive preview.
+        """
+        p_full = _full_preview()
+        p_empty = build_contract_preview_payload()
+        self.assertNotEqual(
+            p_full["next_required_action"], p_empty["next_required_action"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usb_creator.py
+++ b/usb_creator.py
@@ -1418,6 +1418,11 @@ if __name__ == "__main__":
     parser.add_argument("--plan-write", action="store_true", help="Generate a dry-run write execution plan")
     parser.add_argument("--audit-plan", action="store_true", help="Generate a dry-run write plan audit trail payload")
     parser.add_argument("--simulate-write", action="store_true", help="Run null-device mock writer simulation. Does not write to target drives.")
+    parser.add_argument("--validate-writer-contract", action="store_true", help="Preview the writer safety contract (read-only, no drive access, JSON output only)")
+    parser.add_argument("--audit-passed", action="store_true", help="(Contract preview) Report audit gate as passed")
+    parser.add_argument("--simulation-passed", action="store_true", help="(Contract preview) Report simulation gate as passed")
+    parser.add_argument("--typed-confirmation", type=str, help="(Contract preview) Typed confirmation phrase for future gate display")
+    parser.add_argument("--destructive-acknowledgement", type=str, help="(Contract preview) Typed acknowledgement phrase for future gate display")
     parser.add_argument("--target-drive", type=str, help="Target drive for write plan generation")
     parser.add_argument("--image", type=str, help="Source OS image for write plan generation")
     parser.add_argument("--export-json", type=str, help="Export write plan audit as JSON to a local path")
@@ -1430,7 +1435,10 @@ if __name__ == "__main__":
     
     args = parser.parse_args()
     
-    if args.simulate_write:
+    if args.validate_writer_contract:
+        from writer_safety_contract import _cli_validate_writer_contract
+        _cli_validate_writer_contract(args)
+    elif args.simulate_write:
         if not args.target_drive or not args.image:
             print(json.dumps({"schema":"bootforge.mock_writer.v1","generated_at":utc_now_iso(),"platform":sys.platform,"safe_mode":True,"destructive":False,"operation":"mock_writer_simulation","actual_write_enabled":False,"target_type":"null_device","status":"blocked","events":[],"error":"Missing required arguments: --target-drive and --image are required with --simulate-write."}, indent=2))
         else:

--- a/writer_safety_contract.py
+++ b/writer_safety_contract.py
@@ -1,7 +1,7 @@
 """
 writer_safety_contract.py
 PhoenixCore / BootForge USB Creator
-Phase 4C-1: Writer Safety Contract Schema + Validator
+Phase 4C-1/4C-2: Writer Safety Contract Schema + Validator + Preview Bridge
 
 This module builds and validates a writer safety contract
 (schema: bootforge.writer_safety_contract.v1).
@@ -10,8 +10,8 @@ It does NOT implement a real USB writer.
 It does NOT write, format, partition, mount, unmount, or access any drive.
 It does NOT call diskpart, dd, WriteFile, or any raw-device API.
 
-All destructive_operations_enabled values are permanently False in Phase 4C-1.
-All real_writer_implemented values are permanently False in Phase 4C-1.
+All destructive_operations_enabled values are permanently False.
+All real_writer_implemented values are permanently False.
 
 The contract enforces every gate defined in the Phase 4B architecture before
 any future writer would be permitted to arm. Currently all write paths remain
@@ -382,6 +382,91 @@ def validate_writer_safety_contract(contract: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Preview bridge — used by CLI and dashboard API route
+# ---------------------------------------------------------------------------
+
+def build_contract_preview_payload(
+    target_drive: str = None,
+    image: str = None,
+    audit_passed: bool = False,
+    simulation_passed: bool = False,
+    typed_confirmation: str = None,
+    destructive_acknowledgement: str = None,
+) -> dict:
+    """
+    Build a read-only writer safety contract preview payload.
+
+    This is the single entry-point used by both the CLI
+    (--validate-writer-contract) and the dashboard API route
+    (GET /api/write/contract).
+
+    It builds minimal device/image identity from path metadata only.
+    It does NOT open, read, query, mount, or write to any drive.
+    It does NOT call diskpart, dd, WriteFile, or any raw-device API.
+    Output is always blocked in Phase 4C-2 (real_writer_implemented=False).
+
+    Parameters
+    ----------
+    target_drive             : Path string of candidate target drive.
+    image                    : Path string of candidate image file.
+    audit_passed             : Whether the caller reports audit gate as passed.
+    simulation_passed        : Whether the caller reports simulation gate as passed.
+    typed_confirmation       : Typed confirmation phrase (future gate — not checked here).
+    destructive_acknowledgement : Typed acknowledgement (future gate — not checked here).
+
+    Returns
+    -------
+    JSON-serializable dict with schema bootforge.writer_safety_contract.v1.
+    Always blocked. Never enables real writing.
+    """
+    from pathlib import Path as _Path
+
+    dev_id = None
+    img_id = None
+
+    if target_drive and str(target_drive).strip():
+        dev_id = build_device_identity(root_path=str(target_drive).strip())
+
+    if image and str(image).strip():
+        p = _Path(str(image).strip())
+        img_id = build_image_identity(
+            image_path=str(p),
+            filename=p.name,
+            extension=p.suffix.lower() if p.suffix else None,
+            size_bytes=p.stat().st_size if p.exists() else None,
+        )
+
+    # Build gate_results from the caller-supplied context.
+    # Future-only gates (typed confirmation / destructive acknowledgement)
+    # are recorded but do not unlock any writer.
+    gate_results = {
+        "drive_selected": bool(target_drive and str(target_drive).strip()),
+        "image_selected": bool(image and str(image).strip()),
+        "drive_safety_scanned": bool(dev_id),
+        "image_inspected": bool(img_id),
+        "write_plan_generated": bool(audit_passed),  # plan must precede audit
+        "audit_passed": bool(audit_passed),
+        "simulation_passed": bool(simulation_passed),
+        # Future confirmation gates — present but do not affect Phase 4C-2 blocking
+        "fresh_device_rescan_required": False,
+        "typed_confirmation_required": bool(typed_confirmation and str(typed_confirmation).strip()),
+        "destructive_acknowledgement_required": bool(
+            destructive_acknowledgement and str(destructive_acknowledgement).strip()
+        ),
+        "final_confirmation_token_required": False,
+    }
+
+    contract = build_writer_safety_contract(
+        target_drive=target_drive,
+        image=image,
+        device_identity=dev_id,
+        image_identity=img_id,
+        gate_results=gate_results,
+    )
+    return contract
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point (non-destructive — prints contract JSON only)
 # ---------------------------------------------------------------------------
 
@@ -389,37 +474,21 @@ def _cli_validate_writer_contract(args):
     """
     --validate-writer-contract
 
-    Builds and prints a writer safety contract JSON for the given
-    --target-drive and --image arguments.
+    Builds and prints a writer safety contract JSON preview.
+    Accepts optional gate flags: --audit-passed, --simulation-passed,
+    --typed-confirmation, --destructive-acknowledgement.
 
     Does NOT write, read, format, partition, mount, or unmount any drive.
     Does NOT call diskpart, dd, WriteFile, or any raw-device API.
     Output is JSON only.
     """
-    drive = getattr(args, "target_drive", None)
-    image = getattr(args, "image", None)
-
-    dev_id = None
-    img_id = None
-
-    if drive:
-        dev_id = build_device_identity(root_path=drive)
-
-    if image:
-        from pathlib import Path as _Path
-        p = _Path(image)
-        img_id = build_image_identity(
-            image_path=str(p),
-            filename=p.name,
-            extension=p.suffix.lower(),
-            size_bytes=p.stat().st_size if p.exists() else None,
-        )
-
-    contract = build_writer_safety_contract(
-        target_drive=drive,
-        image=image,
-        device_identity=dev_id,
-        image_identity=img_id,
+    contract = build_contract_preview_payload(
+        target_drive=getattr(args, "target_drive", None),
+        image=getattr(args, "image", None),
+        audit_passed=bool(getattr(args, "audit_passed", False)),
+        simulation_passed=bool(getattr(args, "simulation_passed", False)),
+        typed_confirmation=getattr(args, "typed_confirmation", None),
+        destructive_acknowledgement=getattr(args, "destructive_acknowledgement", None),
     )
     print(json.dumps(contract, indent=2))
 


### PR DESCRIPTION
## Summary

This PR adds Phase 4C-2: Contract CLI + Dashboard Read-Only Contract Preview.

Phase 4C-2 exposes the existing writer safety contract through a safe CLI/backend path and a read-only dashboard panel. It does not implement a real writer, does not enable destructive operations, and does not add any write, format, partition, mount, unmount, raw disk, `diskpart`, or `dd` behavior.

## What Changed

Added or updated:

- `writer_safety_contract.py`
- `usb_creator.py`
- `dashboard/vite.config.js`
- `dashboard/src/App.jsx`
- `tests/test_writer_safety_contract_preview.py`
- `docs/evidence/phase4c2-contract-cli-dashboard-preview.md`

## Safety Scope

This PR does **not** implement a real writer.

This PR does **not** add:

- USB writing
- Formatting
- Partitioning
- Mount automation
- Unmount automation
- Raw disk access
- `diskpart`
- `dd`
- Bootloader writing
- Destructive target-drive mutation
- A write button
- An arm-writer button

The preview remains read-only and preserves:

```text
real_writer_implemented: false
destructive_operations_enabled: false
```

## CLI / Backend Behavior

The CLI/backend path exposes writer safety contract validation using:

```text
--validate-writer-contract
```

This path only prints JSON. It does not touch, open, mount, unmount, format, write, or mutate any drive.

## Dashboard Behavior

Added read-only endpoint:

```text
GET /api/write/contract
```

Added dashboard panel:

```text
Writer Safety Contract Preview
```

The panel displays:

- schema
- contract ID
- blocked status
- real writer implemented status
- destructive operations enabled status
- next required action
- required gates
- gate results
- block reasons
- warnings
- device identity hash when present
- image identity hash when present

Required safety copy is present:

```text
Read-only safety contract preview. No USB write, format, partition, mount, unmount, raw disk access, or destructive operation is available.
```

Button label:

```text
Preview Writer Safety Contract
```

## Tests

Added `tests/test_writer_safety_contract_preview.py`.

The test suite verifies:

- contract preview schema is `bootforge.writer_safety_contract.v1`
- `real_writer_implemented` remains false
- `destructive_operations_enabled` remains false
- missing drive blocks
- missing image blocks
- valid mock preview still does not enable writing
- payload is JSON serializable
- forbidden destructive Python call sites are absent
- CLI preview stays non-destructive
- deterministic preview behavior
- dashboard forbidden labels are not introduced

## Validation Results

Backend tests:

```text
91/91 OK
```

Dashboard build:

```text
✓ built in 2.49s
```

## Evidence

Evidence document added:

```text
docs/evidence/phase4c2-contract-cli-dashboard-preview.md
```

## Tag

Phase lock tag:

```text
phase4c2-contract-cli-dashboard-preview-lock
```

## Recommended Next Phase

After review and merge, the next phase should remain non-destructive.

Recommended next milestone:

**Phase 4C-3: Contract Persistence + Evidence Export**

Phase 4C-3 should allow exporting or recording read-only contract preview evidence without introducing any real writer implementation.