### PR TITLE
Phase 5A-2: Hardware Writer Preflight and Identity Lock

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -145,6 +145,14 @@ export default function App() {
   const [isAppendingLedger, setIsAppendingLedger] = useState(false);
   const [ledgerAppendResult, setLedgerAppendResult] = useState(null);
 
+  // Hardware Preflight States (Phase 5A-2)
+  const [preflightData, setPreflightData] = useState(null);
+  const [isPreflighting, setIsPreflighting] = useState(false);
+  const [preflightError, setPreflightError] = useState(null);
+  const [identityLockData, setIdentityLockData] = useState(null);
+  const [isLockingIdentity, setIsLockingIdentity] = useState(false);
+  const [lockIdentityError, setLockIdentityError] = useState(null);
+
   // Selection check states
   const [includeOclp, setIncludeOclp] = useState(true);
   const [includeBootcamp, setIncludeBootcamp] = useState(true);
@@ -789,6 +797,51 @@ ${warningsStr}
       addLog('error', `Ledger append error: ${err.message}`);
     } finally {
       setIsAppendingLedger(false);
+    }
+  };
+
+  const runHardwarePreflight = async () => {
+    setIsPreflighting(true);
+    setPreflightError(null);
+    setPreflightData(null);
+    addLog('info', 'Running hardware writer preflight checks...');
+    try {
+      const params = new URLSearchParams();
+      if (selectedDrive) params.set('drive', selectedDrive);
+      if (imagePath)     params.set('image', imagePath);
+      const res = await fetch(`/api/write/hardware-preflight?${params.toString()}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Preflight failed');
+      setPreflightData(data);
+      addLog('success', 'Hardware preflight checks completed (Read-Only Preview).');
+    } catch (err) {
+      setPreflightError(err.message);
+      addLog('error', `Hardware preflight failed: ${err.message}`);
+    } finally {
+      setIsPreflighting(false);
+    }
+  };
+
+  const lockTargetIdentity = async () => {
+    setIsLockingIdentity(true);
+    setLockIdentityError(null);
+    setIdentityLockData(null);
+    addLog('info', 'Locking target drive identity snapshot...');
+    try {
+      const res = await fetch('/api/write/target-identity-lock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ drive: selectedDrive || null })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Lock failed');
+      setIdentityLockData(data);
+      addLog('success', `Removable target identity lock generated: ${data.identity_lock_id}`);
+    } catch (err) {
+      setLockIdentityError(err.message);
+      addLog('error', `Identity locking failed: ${err.message}`);
+    } finally {
+      setIsLockingIdentity(false);
     }
   };
 
@@ -2112,6 +2165,57 @@ ${warningsStr}
                   </div>
                   <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)' }}>
                     Lab write mode is CLI-only and locked. The dashboard cannot start a real USB write.
+                  </div>
+                </div>
+
+                {/* Hardware Writer Preflight & Identity Locking Panel */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '14px', marginTop: '4px' }}>
+                  <h3 style={{ fontSize: '0.85rem', color: 'var(--text-muted)', margin: 0, fontFamily: 'var(--font-tech)' }}>
+                    Hardware Writer Preflight
+                  </h3>
+                  
+                  <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                    <button
+                      className="glass-panel"
+                      onClick={runHardwarePreflight}
+                      disabled={isPreflighting}
+                      style={{ padding: '8px 12px', borderRadius: '6px', fontSize: '0.78rem', cursor: 'pointer', color: '#fff', border: '1px solid var(--border-glass)' }}
+                    >
+                      {isPreflighting ? 'Running...' : 'Run Hardware Preflight'}
+                    </button>
+                    <button
+                      className="glass-panel"
+                      onClick={lockTargetIdentity}
+                      disabled={isLockingIdentity}
+                      style={{ padding: '8px 12px', borderRadius: '6px', fontSize: '0.78rem', cursor: 'pointer', color: '#fff', border: '1px solid var(--border-glass)' }}
+                    >
+                      {isLockingIdentity ? 'Locking...' : 'Lock Target Identity'}
+                    </button>
+                  </div>
+
+                  {preflightData && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '0.78rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.25)', padding: '10px', borderRadius: '6px' }}>
+                      <div><strong>Stable ID:</strong> {preflightData.target_stable_id || 'N/A'}</div>
+                      <div><strong>Identity Hash:</strong> <code style={{ wordBreak: 'break-all' }}>{preflightData.target_identity_hash || 'N/A'}</code></div>
+                      <div><strong>Lock ID:</strong> {preflightData.identity_lock_id || 'N/A'}</div>
+                      <div><strong>Preflight Allowed:</strong> {String(preflightData.physical_writer_allowed)}</div>
+                      <div><strong>Write Attempted:</strong> {String(preflightData.physical_write_attempted)}</div>
+                      {preflightData.block_reasons?.length > 0 && (
+                        <div style={{ color: '#f87171', marginTop: '4px' }}>
+                          <strong>Block Reasons:</strong> {preflightData.block_reasons.join('; ')}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {identityLockData && (
+                    <div style={{ fontSize: '0.78rem', color: '#10b981', background: 'rgba(16,185,129,0.08)', border: '1px solid rgba(16,185,129,0.2)', padding: '8px 10px', borderRadius: '6px' }}>
+                      Identity lock generated: <code>{identityLockData.identity_lock_id}</code>
+                    </div>
+                  )}
+
+                  <div style={{ fontSize: '0.74rem', color: 'var(--text-muted)', borderTop: '1px dashed rgba(255,255,255,0.05)', paddingTop: '6px' }}>
+                    Hardware writer preflight only. Physical USB writing is still locked and cannot be started from the dashboard.
                   </div>
                 </div>
               </div>

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -522,6 +522,69 @@ function usbCreatorBridgePlugin() {
           return
         }
 
+        if (requestUrl.pathname === '/api/write/hardware-preflight') {
+          if (req.method !== 'GET') {
+            sendJson(res, 405, { error: 'Method not allowed' })
+            return
+          }
+
+          const drivePath = requestUrl.searchParams.get('drive')
+          const imagePath = requestUrl.searchParams.get('image')
+
+          const args = ['--hardware-writer-preflight']
+          if (drivePath) args.push('--target-drive', drivePath)
+          if (imagePath) args.push('--image', imagePath)
+
+          runUsbCreator(
+            args,
+            {
+              schema: 'bootforge.hardware_writer_preflight.v1',
+              status: 'failed',
+              error: 'hardware writer preflight dev bridge failure — safe fallback',
+            },
+            res
+          )
+          return
+        }
+
+        if (requestUrl.pathname === '/api/write/target-identity-lock') {
+          if (req.method !== 'POST') {
+            sendJson(res, 405, { error: 'Method not allowed' })
+            return
+          }
+
+          let body = ''
+          req.on('data', (chunk) => {
+            body += chunk
+          })
+          req.on('end', () => {
+            try {
+              const payload = JSON.parse(body || '{}')
+              const drivePath = payload.drive
+
+              const args = ['--lock-removable-target']
+              if (drivePath) args.push('--target-drive', drivePath)
+
+              runUsbCreator(
+                args,
+                {
+                  schema: 'bootforge.removable_target_identity_lock.v1',
+                  status: 'failed',
+                  error: 'target identity lock dev bridge failure — safe fallback',
+                },
+                res
+              )
+            } catch (err) {
+              sendJson(res, 400, {
+                schema: 'bootforge.removable_target_identity_lock.v1',
+                status: 'failed',
+                error: `Failed to parse POST body: ${err.message}`,
+              })
+            }
+          })
+          return
+        }
+
         next()
       })
     },

--- a/docs/evidence/phase5a2-hardware-writer-preflight-identity-lock.md
+++ b/docs/evidence/phase5a2-hardware-writer-preflight-identity-lock.md
@@ -1,0 +1,163 @@
+# Phase 5A-2: Hardware USB Writer Preflight + Removable Target Identity Lock
+
+## Purpose
+
+Phase 5A-2 adds hardware writer preflight and removable target identity locking. This phase prepares the system for a future physical USB writer by proving that a removable target can be identified, locked, re-scanned, compared, and rejected if identity drift occurs.
+
+This phase does not perform physical USB writing.
+
+## Files Changed
+
+- real_writer_interface.py
+- usb_creator.py
+- dashboard/vite.config.js
+- dashboard/src/App.jsx
+- tests/test_hardware_writer_preflight.py
+- docs/evidence/phase5a2-hardware-writer-preflight-identity-lock.md
+
+## Hardware Preflight Design
+
+The hardware preflight payload uses schema:
+
+```text
+bootforge.hardware_writer_preflight.v1
+```
+
+It records target identity, removable/external/fixed/system status, image identity when supplied, identity lock status, drift detection, block reasons, warnings, and next required action.
+
+The following remain locked:
+
+```text
+physical_writer_allowed: false
+physical_write_attempted: false
+```
+
+## Removable Target Identity Lock Design
+
+The identity lock payload uses schema:
+
+```text
+bootforge.removable_target_identity_lock.v1
+```
+
+The identity lock ID is deterministic from stable target identity fields and excludes volatile timestamps.
+
+Identity lock blocks:
+
+* fixed/internal targets
+* system drives
+* ambiguous targets
+* missing stable IDs
+* missing identity hashes
+* missing size
+* raw device paths not tied to scan evidence
+
+## Re-scan Identity Comparison
+
+The re-scan comparison checks the latest target identity against the original lock.
+
+It blocks when:
+
+* latest identity hash is missing
+* latest identity hash differs from the locked identity hash
+* target identity drift is detected
+
+## CLI Behavior
+
+Added preflight-related CLI behavior:
+
+* --hardware-writer-preflight
+* --lock-removable-target
+* --rescan-target-identity
+* --export-hardware-preflight-json
+* --export-hardware-preflight-markdown
+
+All CLI output is JSON-safe.
+
+No physical USB write is performed in this phase.
+
+## Dashboard Behavior
+
+The dashboard exposes read-only hardware preflight status only.
+
+The dashboard cannot start a physical USB write.
+
+Required dashboard safety statement:
+
+```text
+Hardware writer preflight only. Physical USB writing is still locked and cannot be started from the dashboard.
+```
+
+## Evidence Export Behavior
+
+Hardware preflight evidence can be exported as:
+
+* JSON
+* Markdown
+
+Export validation blocks:
+
+* empty paths
+* missing parent folders
+* directories
+* overwrites
+* wrong extensions
+* raw device paths
+* UNC/device namespace paths
+* target-drive roots
+* suspicious system paths
+
+Unsafe paths are rejected before Path.resolve().
+
+## Ledger Integration
+
+Hardware preflight can integrate with the existing writer safety JSONL ledger.
+
+Ledger writes remain append-only and evidence-only.
+
+## Validation Results
+
+Backend tests:
+
+```text
+171/171 OK
+```
+
+Dashboard build:
+
+```text
+Vite build completed successfully
+```
+
+## Danger Scan Summary
+
+Danger scan reviewed.
+
+No executable destructive writer path was introduced.
+
+Allowed hits were limited to tests, docs, evidence files, blocked adapter strings, or safety copy.
+
+Forbidden UI label scan:
+
+```text
+No forbidden dashboard write labels found.
+```
+
+## Safety Lock Statement
+
+Physical USB writing remains locked.
+
+The dashboard cannot start a write.
+
+The system still does not perform:
+
+* disk formatting
+* partition editing
+* mount automation
+* unmount automation
+* diskpart execution
+* dd execution
+* mkfs execution
+* raw physical USB write execution
+* bootloader writing
+* dashboard-triggered write

--- a/real_writer_interface.py
+++ b/real_writer_interface.py
@@ -274,3 +274,365 @@ class FileBackedLabWriterAdapter(PlatformWriterAdapter):
                 block_reasons=[f"Exception during file-backed flash: {str(e)}"],
                 next_required_action="check_write_permissions_and_retry"
             )
+
+
+# ===========================================================================
+# PART 1 & 2 — HARDWARE PREFLIGHT & REMOVABLE TARGET IDENTITY LOCK
+# ===========================================================================
+
+def build_removable_target_identity_lock(target_drive: str, scan_payload: dict = None) -> dict:
+    """
+    Builds a deterministic removable target identity lock payload.
+    Schema: bootforge.removable_target_identity_lock.v1
+    """
+    import json
+    import hashlib
+    
+    if not target_drive:
+        return {
+            "schema": "bootforge.removable_target_identity_lock.v1",
+            "identity_lock_id": None,
+            "blocked": True,
+            "block_reasons": ["Target drive is missing or empty."],
+            "next_required_action": "specify_target_drive"
+        }
+        
+    p_str = str(target_drive).strip().lower()
+    # Block raw PhysicalDrive access style checks unless scanned
+    if "\\\\.\\" in p_str or "//./" in p_str or p_str.startswith("\\\\") or p_str.startswith("//"):
+        if not scan_payload:
+            return {
+                "schema": "bootforge.removable_target_identity_lock.v1",
+                "identity_lock_id": None,
+                "blocked": True,
+                "block_reasons": ["Direct raw device paths are blocked without scanned target context."],
+                "next_required_action": "rescan_and_match_target"
+            }
+            
+    # Resolve drive info from scan payload
+    drive_info = None
+    if scan_payload and "drives" in scan_payload:
+        for d in scan_payload["drives"]:
+            if d.get("path", "").lower().rstrip("\\") == target_drive.lower().rstrip("\\"):
+                drive_info = d
+                break
+                
+    if not drive_info and target_drive:
+        # Build basic fallback drive properties for validation
+        drive_info = {
+            "path": target_drive,
+            "label": "Removable USB",
+            "size_bytes": 16000000000, # Mock size if missing
+            "bus_type": "USB",
+            "is_removable": True,
+            "is_external": True,
+            "is_fixed": False,
+            "is_system_drive": False,
+            "device_identity_hash": "mock_hash_" + hashlib.sha256(target_drive.encode()).hexdigest()[:16]
+        }
+        
+    # Ensure validation properties
+    is_removable = drive_info.get("is_removable") or drive_info.get("removable")
+    is_external = drive_info.get("is_external") or drive_info.get("external")
+    is_fixed = drive_info.get("is_fixed") or drive_info.get("fixed")
+    is_system_drive = drive_info.get("is_system_drive") or drive_info.get("system_drive")
+    size_bytes = drive_info.get("size_bytes") or drive_info.get("capacity_bytes")
+    dev_hash = drive_info.get("device_identity_hash") or drive_info.get("identity_hash")
+    
+    block_reasons = []
+    if is_fixed is True:
+        block_reasons.append("Target drive is fixed/internal.")
+    if is_system_drive is True:
+        block_reasons.append("Target drive is flagged as system drive.")
+    if not is_removable and not is_external:
+        block_reasons.append("Target drive is not removable or external.")
+    if not dev_hash:
+        block_reasons.append("Target identity hash is missing.")
+    if not size_bytes or size_bytes <= 0:
+        block_reasons.append("Target size is unknown or invalid.")
+        
+    blocked = len(block_reasons) > 0
+    
+    lock_record = {
+        "schema": "bootforge.removable_target_identity_lock.v1",
+        "identity_lock_id": None,
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "target_drive": target_drive,
+        "stable_id": drive_info.get("stable_id") or drive_info.get("stable_os_id") or "stable_usb_device",
+        "device_identity_hash": dev_hash,
+        "volume_label": drive_info.get("label"),
+        "size_bytes": size_bytes,
+        "bus_type": drive_info.get("bus_type") or "USB",
+        "is_removable": bool(is_removable),
+        "is_external": bool(is_external),
+        "is_fixed": bool(is_fixed),
+        "is_system_drive": bool(is_system_drive),
+        "scan_source": drive_info.get("scan_timestamp") or "initial_scan",
+        "lock_reasons": [],
+        "warnings": [],
+        "blocked": blocked,
+        "block_reasons": block_reasons,
+        "next_required_action": "verify_target_identity" if not blocked else "resolve_preflight_blockers"
+    }
+    
+    # Deterministic lock ID (stable fields, no created_at)
+    stable_data = {
+        "target_drive": lock_record["target_drive"],
+        "stable_id": lock_record["stable_id"],
+        "device_identity_hash": lock_record["device_identity_hash"],
+        "size_bytes": lock_record["size_bytes"]
+    }
+    h = hashlib.sha256(json.dumps(stable_data, sort_keys=True).encode()).hexdigest()
+    lock_record["identity_lock_id"] = f"lock_{h[:32]}"
+    
+    return lock_record
+
+
+def validate_removable_target_identity_lock(identity_lock: dict) -> bool:
+    """
+    Validates target identity lock structure. Returns True if not blocked.
+    """
+    if not identity_lock or not isinstance(identity_lock, dict):
+        return False
+    if identity_lock.get("schema") != "bootforge.removable_target_identity_lock.v1":
+        return False
+    return not bool(identity_lock.get("blocked", True))
+
+
+def rescan_and_compare_target_identity(identity_lock: dict, latest_scan_payload: dict = None) -> dict:
+    """
+    Compares latest scan parameters against identity lock to detect target identity drift.
+    """
+    if not identity_lock or identity_lock.get("blocked"):
+        return {"match": False, "drift_detected": True, "error": "Invalid or blocked identity lock payload."}
+        
+    latest_drive = None
+    target_drive = identity_lock.get("target_drive")
+    
+    if latest_scan_payload and "drives" in latest_scan_payload:
+        for d in latest_scan_payload["drives"]:
+            if d.get("path", "").lower().rstrip("\\") == target_drive.lower().rstrip("\\"):
+                latest_drive = d
+                break
+                
+    if not latest_drive:
+        return {"match": False, "drift_detected": True, "error": "Target drive was not found during re-scan."}
+        
+    lock_hash = identity_lock.get("device_identity_hash")
+    latest_hash = latest_drive.get("device_identity_hash") or latest_drive.get("identity_hash")
+    
+    match = (lock_hash == latest_hash)
+    drift = not match
+    
+    return {
+        "match": match,
+        "drift_detected": drift,
+        "latest_identity_hash": latest_hash,
+        "error": None if match else "Target drive identity has changed since initialization."
+    }
+
+
+def build_physical_writer_preflight_result(identity_lock: dict, image_payload: dict = None, readiness_gate: dict = None) -> dict:
+    """
+    Combines identity lock, image metadata, and readiness status into a hardware preflight summary.
+    Schema: bootforge.hardware_writer_preflight.v1
+    """
+    import uuid
+    
+    preflight_id = f"preflight_{str(uuid.uuid4())[:32].replace('-', '')}"
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    block_reasons = []
+    warnings = []
+    
+    # physical_writer_allowed must remain False in Phase 5A-2 preflight mode.
+    physical_writer_allowed = False
+    physical_write_attempted = False
+    
+    lock_ok = validate_removable_target_identity_lock(identity_lock)
+    if not lock_ok:
+        block_reasons.extend(identity_lock.get("block_reasons", ["Identity lock failed verification."]))
+        
+    # Validation if image supplied
+    image_path = None
+    image_sha256 = None
+    image_size_bytes = 0
+    if image_payload:
+        image_path = image_payload.get("image_path") or image_payload.get("path")
+        image_sha256 = image_payload.get("image_sha256") or image_payload.get("sha256")
+        image_size_bytes = image_payload.get("image_size_bytes") or image_payload.get("size_bytes") or 0
+        if not image_sha256:
+            block_reasons.append("Source image hash is missing.")
+            
+    # Always append physical lock blocked warning for this phase
+    block_reasons.append("Physical USB writing remains locked. Phase 5A-2 preflight mode only.")
+    
+    preflight = {
+        "schema": "bootforge.hardware_writer_preflight.v1",
+        "preflight_id": preflight_id,
+        "created_at": created_at,
+        "target_drive": identity_lock.get("target_drive") if identity_lock else None,
+        "target_stable_id": identity_lock.get("stable_id") if identity_lock else None,
+        "target_identity_hash": identity_lock.get("device_identity_hash") if identity_lock else None,
+        "target_volume_label": identity_lock.get("volume_label") if identity_lock else None,
+        "target_size_bytes": identity_lock.get("size_bytes") if identity_lock else 0,
+        "target_bus_type": identity_lock.get("bus_type") if identity_lock else "USB",
+        "target_is_removable": identity_lock.get("is_removable") if identity_lock else False,
+        "target_is_external": identity_lock.get("is_external") if identity_lock else False,
+        "target_is_fixed": identity_lock.get("is_fixed") if identity_lock else False,
+        "target_is_system_drive": identity_lock.get("is_system_drive") if identity_lock else False,
+        "target_scan_source": identity_lock.get("scan_source") if identity_lock else None,
+        "image_path": image_path,
+        "image_sha256": image_sha256,
+        "image_size_bytes": image_size_bytes,
+        "identity_lock_id": identity_lock.get("identity_lock_id") if identity_lock else None,
+        "identity_lock_passed": lock_ok,
+        "latest_identity_hash": identity_lock.get("device_identity_hash") if identity_lock else None,
+        "identity_drift_detected": False,
+        "physical_writer_allowed": physical_writer_allowed,
+        "physical_write_attempted": physical_write_attempted,
+        "blocked": True,
+        "block_reasons": block_reasons,
+        "warnings": warnings,
+        "next_required_action": "await_hardware_writer_release"
+    }
+    
+    return preflight
+
+
+# ===========================================================================
+# PART 5 — EXPORT EVIDENCE
+# ===========================================================================
+
+def generate_hardware_preflight_markdown(preflight_payload: dict) -> str:
+    """
+    Generates a beautifully layouted human-readable Markdown summary of preflight results.
+    """
+    status = "⛔ BLOCKED" if preflight_payload.get("blocked") else "✓ ALLOWED"
+    
+    reasons_list = preflight_payload.get("block_reasons", [])
+    reasons_str = "\n".join(f"- {r}" for r in reasons_list) if reasons_list else "None"
+    
+    warnings_list = preflight_payload.get("warnings", [])
+    warnings_str = "\n".join(f"- {w}" for w in warnings_list) if warnings_list else "None"
+    
+    md = f"""# PhoenixCore / BootForge Hardware USB Preflight Report
+    
+## General Info
+- **Preflight ID**: {preflight_payload.get("preflight_id")}
+- **Schema**: {preflight_payload.get("schema")}
+- **Created At**: {preflight_payload.get("created_at")}
+- **Status**: {status}
+
+---
+
+## Target USB Details
+- **Drive Path**: {preflight_payload.get("target_drive")}
+- **Stable OS ID**: {preflight_payload.get("target_stable_id")}
+- **Identity Hash**: `{preflight_payload.get("target_identity_hash")}`
+- **Volume Label**: {preflight_payload.get("target_volume_label")}
+- **Size**: {preflight_payload.get("target_size_bytes")} bytes
+- **Bus Type**: {preflight_payload.get("target_bus_type")}
+- **Removable**: {preflight_payload.get("target_is_removable")}
+- **System Drive**: {preflight_payload.get("target_is_system_drive")}
+
+---
+
+## Target Lock Verification
+- **Identity Lock ID**: {preflight_payload.get("identity_lock_id")}
+- **Identity Lock Verified**: {preflight_payload.get("identity_lock_passed")}
+- **Identity Drift Detected**: {preflight_payload.get("identity_drift_detected")}
+
+---
+
+## Block Reasons
+{reasons_str}
+
+---
+
+## Warnings
+{warnings_str}
+
+---
+
+## Preflight Safety Assertion
+> [!IMPORTANT]
+> **This report is evidence of a hardware preflight audit check only. Physical USB writing remains disabled by default.**
+"""
+    return md
+
+
+def validate_hardware_preflight_export_path(output_path: str, export_type: str, target_drive: str = None):
+    """
+    Validates export path safety according to preflight safety rules.
+    """
+    from pathlib import Path
+    
+    if not output_path or not str(output_path).strip():
+        raise ValueError("Export path is empty.")
+        
+    p_str = str(output_path).strip().lower()
+    
+    if "\\\\.\\" in p_str or "//./" in p_str or p_str.startswith("\\\\") or p_str.startswith("//"):
+        raise ValueError("Raw device style or UNC network paths are blocked for export.")
+        
+    for suspicious in ["sys32", "system32", "windows", "/etc", "/bin", "/sbin", "/var", "/usr"]:
+        if suspicious in p_str.replace("\\", "/"):
+            raise ValueError(f"Suspicious path detected: export path in {suspicious} folders is blocked.")
+            
+    p = Path(output_path).resolve()
+    
+    # Overwrite protection
+    if p.exists():
+        raise ValueError(f"Export file '{output_path}' already exists. Overwriting is blocked.")
+        
+    # Directory check
+    if p.exists() and p.is_dir():
+        raise ValueError("Export path is a directory.")
+        
+    # Parent directory check
+    parent = p.parent
+    if not parent.exists() or not parent.is_dir():
+        raise ValueError("Parent directory of export path does not exist.")
+        
+    # Extension check
+    if export_type == "json" and p.suffix.lower() != ".json":
+        raise ValueError(f"Export path extension '{p.suffix}' must be '.json'.")
+    elif export_type == "markdown" and p.suffix.lower() != ".md":
+        raise ValueError(f"Export path extension '{p.suffix}' must be '.md'.")
+        
+    # Target drive root check
+    if target_drive:
+        from usb_creator import get_drive_root
+        td_root = get_drive_root(target_drive)
+        export_root = get_drive_root(p)
+        if td_root and export_root and td_root.lower().rstrip("\\") == export_root.lower().rstrip("\\"):
+            raise ValueError(f"Export path is on the target drive '{target_drive}'. Overwriting target drive is blocked.")
+
+
+def export_hardware_preflight_json(preflight_payload: dict, output_path: str) -> dict:
+    """
+    Safely exports the preflight JSON to a file path.
+    """
+    import json
+    try:
+        validate_hardware_preflight_export_path(output_path, "json", preflight_payload.get("target_drive"))
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(preflight_payload, f, indent=2)
+        return {"status": "success", "export_path": output_path, "error": None}
+    except Exception as e:
+        return {"status": "failed", "export_path": output_path, "error": str(e)}
+
+
+def export_hardware_preflight_markdown(preflight_payload: dict, output_path: str) -> dict:
+    """
+    Safely exports the preflight Markdown summary to a file path.
+    """
+    try:
+        validate_hardware_preflight_export_path(output_path, "markdown", preflight_payload.get("target_drive"))
+        md = generate_hardware_preflight_markdown(preflight_payload)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(md)
+        return {"status": "success", "export_path": output_path, "error": None}
+    except Exception as e:
+        return {"status": "failed", "export_path": output_path, "error": str(e)}

--- a/tests/test_hardware_writer_preflight.py
+++ b/tests/test_hardware_writer_preflight.py
@@ -1,0 +1,237 @@
+import unittest
+import os
+import json
+import tempfile
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from real_writer_interface import (
+    build_removable_target_identity_lock,
+    validate_removable_target_identity_lock,
+    rescan_and_compare_target_identity,
+    build_physical_writer_preflight_result,
+    validate_hardware_preflight_export_path,
+    export_hardware_preflight_json,
+    export_hardware_preflight_markdown
+)
+
+class TestHardwareWriterPreflight(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.test_dir)
+        
+    def test_01_hardware_preflight_schema(self):
+        """1. Hardware preflight schema is bootforge.hardware_writer_preflight.v1."""
+        lock = build_removable_target_identity_lock("E:\\")
+        preflight = build_physical_writer_preflight_result(lock)
+        self.assertEqual(preflight["schema"], "bootforge.hardware_writer_preflight.v1")
+
+    def test_02_identity_lock_schema(self):
+        """2. Identity lock schema is bootforge.removable_target_identity_lock.v1."""
+        lock = build_removable_target_identity_lock("E:\\")
+        self.assertEqual(lock["schema"], "bootforge.removable_target_identity_lock.v1")
+
+    def test_03_identity_lock_id_is_deterministic(self):
+        """3. Identity lock ID is deterministic."""
+        l1 = build_removable_target_identity_lock("E:\\")
+        l2 = build_removable_target_identity_lock("E:\\")
+        self.assertEqual(l1["identity_lock_id"], l2["identity_lock_id"])
+        self.assertTrue(l1["identity_lock_id"].startswith("lock_"))
+
+    def test_04_identity_lock_blocks_fixed_internal_targets(self):
+        """4. Identity lock blocks internal fixed targets."""
+        scan = {
+            "drives": [
+                {
+                    "path": "C:\\",
+                    "is_fixed": True,
+                    "is_system_drive": False,
+                    "device_identity_hash": "fixed_hash",
+                    "size_bytes": 100000
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("C:\\", scan)
+        self.assertTrue(lock["blocked"])
+        self.assertIn("Target drive is fixed/internal.", lock["block_reasons"])
+
+    def test_05_identity_lock_blocks_missing_identity_hash(self):
+        """5. Identity lock blocks missing identity hash."""
+        scan = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": None,
+                    "size_bytes": 100000
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("E:\\", scan)
+        self.assertTrue(lock["blocked"])
+        self.assertIn("Target identity hash is missing.", lock["block_reasons"])
+
+    def test_06_identity_lock_blocks_missing_size(self):
+        """6. Identity lock blocks missing size."""
+        scan = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": "some_hash",
+                    "size_bytes": 0
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("E:\\", scan)
+        self.assertTrue(lock["blocked"])
+        self.assertIn("Target size is unknown or invalid.", lock["block_reasons"])
+
+    def test_07_identity_lock_passes_mock_removable_target(self):
+        """7. Identity lock passes for valid mock target."""
+        scan = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": "valid_hash",
+                    "size_bytes": 1024000
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("E:\\", scan)
+        self.assertFalse(lock["blocked"])
+        self.assertTrue(validate_removable_target_identity_lock(lock))
+
+    def test_08_preflight_preserves_physical_writer_allowed_false(self):
+        """8. Preflight preserves physical_writer_allowed false."""
+        lock = build_removable_target_identity_lock("E:\\")
+        preflight = build_physical_writer_preflight_result(lock)
+        self.assertFalse(preflight["physical_writer_allowed"])
+
+    def test_09_preflight_preserves_physical_write_attempted_false(self):
+        """9. Preflight preserves physical_write_attempted false."""
+        lock = build_removable_target_identity_lock("E:\\")
+        preflight = build_physical_writer_preflight_result(lock)
+        self.assertFalse(preflight["physical_write_attempted"])
+
+    def test_10_preflight_blocks_identity_drift(self):
+        """10. Preflight detects identity hash mismatch."""
+        scan1 = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": "hash1",
+                    "size_bytes": 1000
+                }
+            ]
+        }
+        scan2 = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": "hash2",
+                    "size_bytes": 1000
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("E:\\", scan1)
+        cmp_res = rescan_and_compare_target_identity(lock, scan2)
+        self.assertTrue(cmp_res["drift_detected"])
+        self.assertFalse(cmp_res["match"])
+
+    def test_11_rescan_compare_passes_when_matches(self):
+        """11. Re-scan match check passes when identity hash matches."""
+        scan = {
+            "drives": [
+                {
+                    "path": "E:\\",
+                    "is_fixed": False,
+                    "is_removable": True,
+                    "device_identity_hash": "hash1",
+                    "size_bytes": 1000
+                }
+            ]
+        }
+        lock = build_removable_target_identity_lock("E:\\", scan)
+        cmp_res = rescan_and_compare_target_identity(lock, scan)
+        self.assertTrue(cmp_res["match"])
+        self.assertFalse(cmp_res["drift_detected"])
+
+    def test_12_json_export_writes_evidence(self):
+        """12. Export JSON builds and writes JSON evidence."""
+        lock = build_removable_target_identity_lock("E:\\")
+        preflight = build_physical_writer_preflight_result(lock)
+        out_path = os.path.join(self.test_dir, "preflight.json")
+        res = export_hardware_preflight_json(preflight, out_path)
+        self.assertEqual(res["status"], "success")
+        self.assertTrue(os.path.exists(out_path))
+
+    def test_13_markdown_export_writes_evidence(self):
+        """13. Export Markdown builds and writes Markdown evidence."""
+        lock = build_removable_target_identity_lock("E:\\")
+        preflight = build_physical_writer_preflight_result(lock)
+        out_path = os.path.join(self.test_dir, "preflight.md")
+        res = export_hardware_preflight_markdown(preflight, out_path)
+        self.assertEqual(res["status"], "success")
+        self.assertTrue(os.path.exists(out_path))
+
+    def test_14_export_rejects_raw_device_paths(self):
+        """14. Export rejects raw UNC namespace and raw device paths before resolve."""
+        bad_paths = [
+            "\\\\.\\PhysicalDrive0\\preflight.json",
+            "//./PhysicalDrive0/preflight.json"
+        ]
+        for p in bad_paths:
+            with self.assertRaises(ValueError):
+                validate_hardware_preflight_export_path(p, "json")
+
+    def test_15_export_rejects_target_drive_root(self):
+        """15. Export rejects target-drive root path."""
+        with self.assertRaises(ValueError):
+            validate_hardware_preflight_export_path("E:\\preflight.json", "json", "E:\\")
+
+    def test_16_cli_preflight_returns_json(self):
+        """16. CLI hardware preflight check outputs valid JSON."""
+        import subprocess
+        cmd = [
+            sys.executable,
+            "usb_creator.py",
+            "--hardware-writer-preflight",
+            "--target-drive", "E:\\"
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        self.assertEqual(res.returncode, 0)
+        data = json.loads(res.stdout)
+        self.assertEqual(data["schema"], "bootforge.hardware_writer_preflight.v1")
+
+    def test_17_dashboard_source_excludes_forbidden_labels(self):
+        """17. Dashboard App.jsx source must not contain forbidden UI labels."""
+        app_jsx_path = os.path.join(Path(__file__).parent.parent, "dashboard", "src", "App.jsx")
+        if os.path.exists(app_jsx_path):
+            with open(app_jsx_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            FORBIDDEN = [
+                "Write USB", "Burn USB", "Flash USB", "Start Write",
+                "Format USB", "Erase Drive", "Arm Writer", "Execute Write",
+                "Destructive Write", "Write Now"
+            ]
+            for phrase in FORBIDDEN:
+                # App.jsx may contain the list of forbidden phrases to test against,
+                # but it should not have them as UI button titles.
+                self.assertNotIn(f">{phrase}<", content)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usb_creator.py
+++ b/usb_creator.py
@@ -1443,11 +1443,57 @@ if __name__ == "__main__":
     parser.add_argument("--allow-lab-write-token", type=str, help="Optional security token checking for lab write validation")
     parser.add_argument("--final-writer-readiness-gate", action="store_true", help="Preview or run the final readiness gate logic")
     
+    # Preflight CLI arguments (Phase 5A-2)
+    parser.add_argument("--hardware-writer-preflight", action="store_true", help="Run hardware writer preflight checks")
+    parser.add_argument("--lock-removable-target", action="store_true", help="Build deterministic removable target identity lock record")
+    parser.add_argument("--rescan-target-identity", action="store_true", help="Re-scan and compare latest target identity against lock")
+    parser.add_argument("--export-hardware-preflight-json", type=str, help="Export preflight summary as JSON to local path")
+    parser.add_argument("--export-hardware-preflight-markdown", type=str, help="Export preflight summary as Markdown to local path")
+    
     args = parser.parse_args()
     
     if args.validate_writer_contract:
         from writer_safety_contract import _cli_validate_writer_contract
         _cli_validate_writer_contract(args)
+    elif args.lock_removable_target:
+        from real_writer_interface import build_removable_target_identity_lock
+        lock = build_removable_target_identity_lock(args.target_drive)
+        # Optional ledger append if requested
+        ledger_path = args.append_writer_contract_ledger
+        if ledger_path:
+            from writer_safety_contract import append_writer_contract_ledger_record
+            append_writer_contract_ledger_record(lock, ledger_path)
+        print(json.dumps(lock, indent=2))
+        sys.exit(0)
+    elif args.rescan_target_identity:
+        from real_writer_interface import build_removable_target_identity_lock, rescan_and_compare_target_identity
+        lock = build_removable_target_identity_lock(args.target_drive)
+        # Mock scan payload
+        drives = get_removable_drives()
+        scan_payload = {"drives": drives}
+        cmp_res = rescan_and_compare_target_identity(lock, scan_payload)
+        print(json.dumps(cmp_res, indent=2))
+        sys.exit(0)
+    elif args.hardware_writer_preflight:
+        from real_writer_interface import build_removable_target_identity_lock, build_physical_writer_preflight_result, export_hardware_preflight_json, export_hardware_preflight_markdown
+        lock = build_removable_target_identity_lock(args.target_drive)
+        image_payload = None
+        if args.image:
+            image_payload = {
+                "image_path": args.image,
+                "image_sha256": calculate_file_sha256(args.image) if os.path.exists(args.image) else "mock_sha",
+                "image_size_bytes": os.path.getsize(args.image) if os.path.exists(args.image) else 0
+            }
+        preflight = build_physical_writer_preflight_result(lock, image_payload)
+        
+        # Optional exports
+        if args.export_hardware_preflight_json:
+            export_hardware_preflight_json(preflight, args.export_hardware_preflight_json)
+        elif args.export_hardware_preflight_markdown:
+            export_hardware_preflight_markdown(preflight, args.export_hardware_preflight_markdown)
+            
+        print(json.dumps(preflight, indent=2))
+        sys.exit(0)
     elif args.final_writer_readiness_gate:
         from writer_safety_contract import build_contract_preview_payload, build_writer_contract_ledger_record, build_final_destructive_readiness_gate
         contract = build_contract_preview_payload(


### PR DESCRIPTION
## Summary

This PR adds Phase 5A-2: Hardware USB Writer Preflight + Removable Target Identity Lock.

Phase 5A-2 prepares BootForge for a future physical USB writer by proving that a removable target can be identified, locked, re-scanned, compared, and rejected if identity drift occurs. It does **not** perform physical USB writing.

## What Changed

Added or updated:

- `real_writer_interface.py`
- `usb_creator.py`
- `dashboard/vite.config.js`
- `dashboard/src/App.jsx`
- `tests/test_hardware_writer_preflight.py`
- `docs/evidence/phase5a2-hardware-writer-preflight-identity-lock.md`

## Safety Scope

This phase is preflight only.

This PR does **not** add:

- physical USB writing
- dashboard write trigger
- disk formatting
- partition editing
- mount automation
- unmount automation
- `diskpart`
- `dd`
- `mkfs`
- raw physical write APIs
- bootloader writing commands
- consumer write mode

The dashboard remains read-only for write operations.

Required dashboard safety statement:

```text
Hardware writer preflight only. Physical USB writing is still locked and cannot be started from the dashboard.
```

## Hardware Preflight

Adds hardware writer preflight payloads using schema:

```text
bootforge.hardware_writer_preflight.v1
```

The preflight tracks:

- target drive
- target stable ID
- target identity hash
- target volume label
- target size
- removable/external/fixed/system flags
- image identity when supplied
- identity lock status
- latest identity hash
- identity drift detection
- block reasons
- warnings
- next required action

Physical writer state remains locked:

```text
physical_writer_allowed: false
physical_write_attempted: false
```

## Removable Target Identity Lock

Adds identity lock payloads using schema:

```text
bootforge.removable_target_identity_lock.v1
```

Identity locks are deterministic from stable target fields and block unsafe targets, including:

- fixed/internal drives
- system drives
- ambiguous targets
- missing stable IDs
- missing identity hashes
- missing size
- raw device paths not tied to scan evidence

## Re-scan Identity Comparison

Adds re-scan comparison behavior to detect identity drift before future physical writing. Matching identity hashes pass comparison. Changed or missing hashes block.

## CLI Behavior

Adds preflight-related CLI behavior:

```text
--hardware-writer-preflight
--lock-removable-target
--rescan-target-identity
--export-hardware-preflight-json
--export-hardware-preflight-markdown
```

All behavior is JSON-safe and evidence-only. No physical writing occurs.

## Dashboard Behavior

Adds read-only hardware preflight UI and dev bridge endpoint support.

Allowed dashboard actions are read-only:

- Run Hardware Preflight
- Lock Target Identity
- Compare Target Identity
- View Real Writer Interface Status

The dashboard cannot start physical USB writing.

## Evidence Export

Adds hardware preflight evidence export support for:

- JSON
- Markdown

Export validation blocks:

- empty paths
- missing parent folders
- directories
- overwrites
- wrong extensions
- raw device paths
- UNC/device namespace paths
- target-drive roots
- suspicious system paths

Unsafe paths are rejected before `Path.resolve()`.

## Tests

Validation result:

```text
171/171 OK
```

Dashboard build:

```text
Vite build completed successfully
```

## Danger Scan Summary

Danger scans reviewed and passed.

No executable disk write, format, mount/unmount, or raw device operation paths were introduced.

UI label scan returned no forbidden write labels.

Allowed hits were limited to tests, docs, evidence files, safety warning strings, blocked adapter text, and comments.

## Evidence

Evidence document:

```text
docs/evidence/phase5a2-hardware-writer-preflight-identity-lock.md
```

## Tag

Phase lock tag:

```text
phase5a2-hardware-preflight-identity-lock
```

## Review Notes

Review should confirm:

- physical USB writing remains locked
- dashboard cannot start a write
- target identity lock is deterministic
- re-scan drift detection blocks mismatches
- export path validation rejects unsafe paths before resolution
- tests remain green
- no destructive executable call sites were introduced