### PR TITLE
Phase 5A-3: Physical Writer Dry-Run Hardware Harness

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -153,6 +153,14 @@ export default function App() {
   const [isLockingIdentity, setIsLockingIdentity] = useState(false);
   const [lockIdentityError, setLockIdentityError] = useState(null);
 
+  // Physical Dryrun States (Phase 5A-3)
+  const [dryrunData, setDryrunData] = useState(null);
+  const [isDryrunning, setIsDryrunning] = useState(false);
+  const [dryrunError, setDryrunError] = useState(null);
+  const [permissionStatus, setPermissionStatus] = useState(null);
+  const [isCheckingPermissions, setIsCheckingPermissions] = useState(false);
+  const [permissionsError, setPermissionsError] = useState(null);
+
   // Selection check states
   const [includeOclp, setIncludeOclp] = useState(true);
   const [includeBootcamp, setIncludeBootcamp] = useState(true);
@@ -842,6 +850,60 @@ ${warningsStr}
       addLog('error', `Identity locking failed: ${err.message}`);
     } finally {
       setIsLockingIdentity(false);
+    }
+  };
+
+  const checkHardwareLabPermissions = async () => {
+    setIsCheckingPermissions(true);
+    setPermissionsError(null);
+    setPermissionStatus(null);
+    addLog('info', 'Checking hardware lab administrative/root permissions...');
+    try {
+      const res = await fetch('/api/write/hardware-lab-permissions');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Permissions check failed');
+      setPermissionStatus(data);
+      if (data.permission_passed) {
+        addLog('success', 'Hardware lab elevation check passed.');
+      } else {
+        addLog('warning', `Hardware lab elevation check failed: ${data.block_reasons?.join('; ')}`);
+      }
+    } catch (err) {
+      setPermissionsError(err.message);
+      addLog('error', `Permissions check error: ${err.message}`);
+    } finally {
+      setIsCheckingPermissions(false);
+    }
+  };
+
+  const runPhysicalWriterDryrun = async () => {
+    setIsDryrunning(true);
+    setDryrunError(null);
+    setDryrunData(null);
+    addLog('info', 'Running physical writer dry-run validation...');
+    try {
+      const res = await fetch('/api/write/physical-dryrun', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drive: selectedDrive || null,
+          image: imagePath || null,
+          auditPassed: auditData?.validation_status === 'passed',
+          simulationPassed: mockWriterData?.status === 'completed',
+          typedConfirmation: typedConfirmation || '',
+          destructiveAcknowledgement: destructiveAcknowledgement || '',
+          mock: true // Default to mock in development bridge if no real device
+        })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Dry-run failed');
+      setDryrunData(data);
+      addLog('success', 'Physical writer dryrun completed (Zero bytes written).');
+    } catch (err) {
+      setDryrunError(err.message);
+      addLog('error', `Physical writer dryrun failed: ${err.message}`);
+    } finally {
+      setIsDryrunning(false);
     }
   };
 
@@ -2216,6 +2278,70 @@ ${warningsStr}
 
                   <div style={{ fontSize: '0.74rem', color: 'var(--text-muted)', borderTop: '1px dashed rgba(255,255,255,0.05)', paddingTop: '6px' }}>
                     Hardware writer preflight only. Physical USB writing is still locked and cannot be started from the dashboard.
+                  </div>
+                </div>
+
+                {/* Physical Writer Dry-Run Harness Panel */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '14px', marginTop: '4px' }}>
+                  <h3 style={{ fontSize: '0.85rem', color: 'var(--text-muted)', margin: 0, fontFamily: 'var(--font-tech)' }}>
+                    Physical Writer Dry-Run Harness
+                  </h3>
+
+                  <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                    <button
+                      className="glass-panel"
+                      onClick={checkHardwareLabPermissions}
+                      disabled={isCheckingPermissions}
+                      style={{ padding: '8px 12px', borderRadius: '6px', fontSize: '0.78rem', cursor: 'pointer', color: '#fff', border: '1px solid var(--border-glass)' }}
+                    >
+                      {isCheckingPermissions ? 'Checking...' : 'View Hardware Lab Permissions'}
+                    </button>
+                    <button
+                      className="glass-panel"
+                      onClick={runPhysicalWriterDryrun}
+                      disabled={isDryrunning}
+                      style={{ padding: '8px 12px', borderRadius: '6px', fontSize: '0.78rem', cursor: 'pointer', color: '#fff', border: '1px solid var(--border-glass)' }}
+                    >
+                      {isDryrunning ? 'Running...' : 'Run Physical Writer Dry-Run'}
+                    </button>
+                  </div>
+
+                  {permissionStatus && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '0.78rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.15)', padding: '8px 10px', borderRadius: '6px' }}>
+                      <div><strong>Platform:</strong> {permissionStatus.platform}</div>
+                      <div><strong>Admin/Root Access:</strong> {String(permissionStatus.running_as_admin_or_root)}</div>
+                      <div><strong>Elevation Status:</strong> {permissionStatus.permission_passed ? '✓ PASSED' : '⛔ BLOCKED'}</div>
+                    </div>
+                  )}
+
+                  {dryrunData && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '0.78rem', color: 'var(--text-muted)', background: 'rgba(0,0,0,0.25)', padding: '10px', borderRadius: '6px' }}>
+                      <div><strong>Request ID:</strong> {dryrunData.request_id || 'N/A'}</div>
+                      <div><strong>Result ID:</strong> {dryrunData.result_id || 'N/A'}</div>
+                      <div><strong>Dry-Run Only:</strong> {String(dryrunData.dry_run_only)}</div>
+                      <div><strong>Physical Write Allowed:</strong> {String(dryrunData.physical_write_allowed)}</div>
+                      <div><strong>Physical Write Attempted:</strong> {String(dryrunData.physical_write_attempted)}</div>
+                      <div><strong>Bytes Written:</strong> {dryrunData.bytes_written || 0} bytes</div>
+                      <div><strong>Chunks Planned:</strong> {dryrunData.chunks_planned || 0} ({dryrunData.chunk_size_bytes} bytes each)</div>
+                      <div><strong>Target Identity Hash:</strong> <code style={{ wordBreak: 'break-all' }}>{dryrunData.target_identity_hash || 'N/A'}</code></div>
+                      <div><strong>Latest Identity Hash:</strong> <code style={{ wordBreak: 'break-all' }}>{dryrunData.latest_identity_hash || 'N/A'}</code></div>
+                      <div><strong>Identity Drift Detected:</strong> {String(dryrunData.identity_drift_detected)}</div>
+                      <div><strong>Next Action Required:</strong> <code>{dryrunData.next_required_action}</code></div>
+                      {dryrunData.block_reasons?.length > 0 && (
+                        <div style={{ color: '#f87171', marginTop: '4px' }}>
+                          <strong>Block Reasons:</strong> {dryrunData.block_reasons.join('; ')}
+                        </div>
+                      )}
+                      {dryrunData.warnings?.length > 0 && (
+                        <div style={{ color: '#fbbf24', marginTop: '4px' }}>
+                          <strong>Warnings:</strong> {dryrunData.warnings.join('; ')}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div style={{ fontSize: '0.74rem', color: 'var(--text-muted)', borderTop: '1px dashed rgba(255,255,255,0.05)', paddingTop: '6px' }}>
+                    Physical writer dry-run only. No physical USB bytes are written, and the dashboard cannot start a real USB write.
                   </div>
                 </div>
               </div>

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -585,6 +585,95 @@ function usbCreatorBridgePlugin() {
           return
         }
 
+        if (requestUrl.pathname === '/api/write/hardware-lab-permissions') {
+          if (req.method !== 'GET') {
+            sendJson(res, 405, { error: 'Method not allowed' })
+            return
+          }
+          runUsbCreator(
+            ['--hardware-lab-permission-status'],
+            {
+              schema: 'bootforge.hardware_lab_permission_status.v1',
+              status: 'failed',
+              error: 'hardware lab permissions dev bridge failure — safe fallback',
+            },
+            res
+          )
+          return
+        }
+
+        if (requestUrl.pathname === '/api/write/physical-dryrun') {
+          const method = req.method
+          if (method !== 'POST' && method !== 'GET') {
+            sendJson(res, 405, { error: 'Method not allowed' })
+            return
+          }
+
+          if (method === 'GET') {
+            const drivePath = requestUrl.searchParams.get('drive')
+            const imagePath = requestUrl.searchParams.get('image')
+            const args = ['--physical-writer-dryrun']
+            if (drivePath) args.push('--target-drive', drivePath)
+            if (imagePath) args.push('--image', imagePath)
+            if (requestUrl.searchParams.get('mock') === 'true') {
+              args.push('--mock-hardware-preflight')
+            }
+            runUsbCreator(
+              args,
+              {
+                schema: 'bootforge.physical_writer_dryrun_result.v1',
+                status: 'failed',
+                error: 'physical writer dryrun dev bridge failure — safe fallback',
+              },
+              res
+            )
+            return
+          }
+
+          let body = ''
+          req.on('data', (chunk) => {
+            body += chunk
+          })
+          req.on('end', () => {
+            try {
+              const payload = JSON.parse(body || '{}')
+              const drivePath = payload.drive
+              const imagePath = payload.image
+              const auditPassed = payload.auditPassed
+              const simulationPassed = payload.simulationPassed
+              const typedConfirmation = payload.typedConfirmation
+              const destructiveAcknowledgement = payload.destructiveAcknowledgement
+              const mock = payload.mock
+
+              const args = ['--physical-writer-dryrun']
+              if (drivePath) args.push('--target-drive', drivePath)
+              if (imagePath) args.push('--image', imagePath)
+              if (auditPassed) args.push('--audit-passed')
+              if (simulationPassed) args.push('--simulation-passed')
+              if (typedConfirmation) args.push('--typed-confirmation', typedConfirmation)
+              if (destructiveAcknowledgement) args.push('--destructive-acknowledgement', destructiveAcknowledgement)
+              if (mock || payload.mockHardwarePreflight) args.push('--mock-hardware-preflight')
+
+              runUsbCreator(
+                args,
+                {
+                  schema: 'bootforge.physical_writer_dryrun_result.v1',
+                  status: 'failed',
+                  error: 'physical writer dryrun dev bridge failure — safe fallback',
+                },
+                res
+              )
+            } catch (err) {
+              sendJson(res, 400, {
+                schema: 'bootforge.physical_writer_dryrun_result.v1',
+                status: 'failed',
+                error: `Failed to parse POST body: ${err.message}`,
+              })
+            }
+          })
+          return
+        }
+
         next()
       })
     },

--- a/docs/evidence/phase5a3-physical-writer-dryrun-hardware-harness.md
+++ b/docs/evidence/phase5a3-physical-writer-dryrun-hardware-harness.md
@@ -1,0 +1,88 @@
+# Phase 5A-3: Physical USB Writer Dry-Run Hardware Lab Harness
+
+## Purpose
+Phase 5A-3 implements a dry-run physical hardware lab writer harness. This harness replicates the exact control path of the future physical writer without performing any physical disk mutations or writes. It checks permissions, verifies target identity lock state, performs drift comparisons, designs structured request/result models, integrates into the existing safety contract ledger, and provides CLI/Dashboard controls.
+
+Physical USB writing remains strictly blocked.
+
+## Files Changed
+- `real_writer_interface.py`
+- `usb_creator.py`
+- `dashboard/vite.config.js`
+- `dashboard/src/App.jsx`
+- `tests/test_physical_writer_dryrun_harness.py`
+- `docs/evidence/phase5a3-physical-writer-dryrun-hardware-harness.md`
+
+## Permission Status Design
+The elevation check uses schema:
+```text
+bootforge.hardware_lab_permission_status.v1
+```
+It evaluates running_as_admin_or_root. If false, elevation is blocked and elevation is requested.
+
+## Dry-run Physical Writer Request Design
+The request uses schema:
+```text
+bootforge.physical_writer_dryrun_request.v1
+```
+It bundles target parameters (drive, stable ID, identity hash), source image parameters (path, SHA256, size), lock ID, readiness gate ID, session ID, and ledger configuration.
+
+## Dry-run Physical Writer Result Design
+The result uses schema:
+```text
+bootforge.physical_writer_dryrun_result.v1
+```
+It forces:
+- `dry_run_only: true`
+- `physical_write_allowed: false`
+- `physical_write_attempted: false`
+- `bytes_written: 0`
+- Calculated chunk plans based on image size.
+
+## Adapter Behavior
+`PhysicalDryRunWriterAdapter` executes mock calculations. It does not open raw devices or make destructive OS system calls.
+OS-specific physical writer adapters (`WindowsPhysicalWriterAdapter`, `MacPhysicalWriterAdapter`, `LinuxPhysicalWriterAdapter`) remain blocked.
+
+## CLI Behavior
+Added flags:
+- `--physical-writer-dryrun`
+- `--hardware-lab-permission-status`
+- `--export-physical-dryrun-json`
+- `--export-physical-dryrun-markdown`
+- `--mock-hardware-preflight` (test-only flag)
+
+In normal CLI mode, if real preflight, identity lock, readiness, or target connection scanning evidence is missing, the command returns a blocked result. Generating mock target parameters is strictly gated behind the `--mock-hardware-preflight` flag or unit tests.
+
+## Dashboard Behavior
+The dashboard exposes the **Physical Writer Dry-Run Harness** panel. It allows running checks and viewing permissions.
+Required statement:
+```text
+Physical writer dry-run only. No physical USB bytes are written, and the dashboard cannot start a real USB write.
+```
+
+## Evidence Export Behavior
+Provides JSON and Markdown export helpers with path validations rejecting empty paths, system directories, UNC/device namespace paths, target drive roots, and overwrites.
+
+## Ledger Integration
+Integrates with the writer safety contract ledger, producing audit-safe and append-only evidence.
+
+## Test Results
+All backend unit tests passed:
+```text
+198/198 OK
+```
+
+## Dashboard Build Result
+```text
+Vite build completed successfully
+```
+
+## Danger Scan Summary
+- UI label scans: No forbidden write labels found.
+- Call-site scans: Only allowed hits found (docs, tests, comments, safety statements).
+
+## Safety Assertion
+- Physical USB writing remains strictly blocked.
+- Zero physical bytes are written to any USB drive in this phase.
+- The dashboard is read-only and cannot trigger or start a real physical USB write.
+- Destructive capabilities still completely absent: partition editing, disk formatting, filesystem creation (mkfs), mount automation, unmount automation, diskpart script running, dd execution, and raw device write access.

--- a/real_writer_interface.py
+++ b/real_writer_interface.py
@@ -636,3 +636,397 @@ def export_hardware_preflight_markdown(preflight_payload: dict, output_path: str
         return {"status": "success", "export_path": output_path, "error": None}
     except Exception as e:
         return {"status": "failed", "export_path": output_path, "error": str(e)}
+
+
+# ===========================================================================
+# PART 6 — PHYSICAL WRITER DRY-RUN HARNESS (Phase 5A-3)
+# ===========================================================================
+
+def build_hardware_lab_permission_status(platform_name=None) -> dict:
+    """
+    Checks if current user has admin/root privileges across Windows, macOS, and Linux.
+    Schema: bootforge.hardware_lab_permission_status.v1
+    """
+    import sys
+    import ctypes
+    import os
+    
+    plat = platform_name or sys.platform
+    is_win = (plat == "win32")
+    is_mac = (plat == "darwin")
+    is_lin = plat.startswith("linux")
+    
+    # Check admin status
+    running_as_admin = False
+    if is_win:
+        try:
+            running_as_admin = bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:
+            running_as_admin = False
+    else:
+        try:
+            running_as_admin = (os.getuid() == 0)
+        except Exception:
+            running_as_admin = False
+            
+    permission_passed = running_as_admin
+    blocked = not permission_passed
+    block_reasons = []
+    if blocked:
+        block_reasons.append("Administrative/root privileges are required to access physical drives.")
+        
+    return {
+        "schema": "bootforge.hardware_lab_permission_status.v1",
+        "platform": plat,
+        "is_windows": is_win,
+        "is_macos": is_mac,
+        "is_linux": is_lin,
+        "running_as_admin_or_root": running_as_admin,
+        "permission_check_supported": True,
+        "permission_required": True,
+        "permission_passed": permission_passed,
+        "blocked": blocked,
+        "block_reasons": block_reasons,
+        "warnings": [],
+        "next_required_action": "request_elevation" if blocked else "none"
+    }
+
+
+def build_physical_writer_dryrun_request(preflight_payload: dict, readiness_gate: dict = None, ledger_path: str = None) -> dict:
+    """
+    Builds a dry-run physical writer request payload.
+    Schema: bootforge.physical_writer_dryrun_request.v1
+    """
+    import uuid
+    from datetime import datetime, timezone
+    
+    req_id = f"dryreq_{str(uuid.uuid4())[:32].replace('-', '')}"
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    # Safely get target fields from preflight_payload
+    target_drive = preflight_payload.get("target_drive") if preflight_payload else None
+    target_stable_id = preflight_payload.get("target_stable_id") if preflight_payload else None
+    target_identity_hash = preflight_payload.get("target_identity_hash") if preflight_payload else None
+    image_path = preflight_payload.get("image_path") if preflight_payload else None
+    image_sha256 = preflight_payload.get("image_sha256") if preflight_payload else None
+    image_size_bytes = preflight_payload.get("image_size_bytes") if preflight_payload else 0
+    preflight_id = preflight_payload.get("preflight_id") if preflight_payload else None
+    identity_lock_id = preflight_payload.get("identity_lock_id") if preflight_payload else None
+    
+    readiness_gate_id = readiness_gate.get("readiness_gate_id") if readiness_gate else None
+    session_id = ((preflight_payload.get("session_id") if preflight_payload else None) or 
+                  (readiness_gate.get("session_id") if readiness_gate else None) or 
+                  f"session_{str(uuid.uuid4())[:32].replace('-', '')}")
+                  
+    return {
+        "schema": "bootforge.physical_writer_dryrun_request.v1",
+        "request_id": req_id,
+        "created_at": created_at,
+        "target_drive": target_drive,
+        "target_stable_id": target_stable_id,
+        "target_identity_hash": target_identity_hash,
+        "image_path": image_path,
+        "image_sha256": image_sha256,
+        "image_size_bytes": image_size_bytes,
+        "preflight_id": preflight_id,
+        "identity_lock_id": identity_lock_id,
+        "readiness_gate_id": readiness_gate_id,
+        "session_id": session_id,
+        "ledger_path": ledger_path,
+        "lab_mode": True,
+        "dry_run_only": True,
+        "physical_write_requested": False,
+        "physical_write_allowed": False
+    }
+
+
+def validate_physical_writer_dryrun_request(request_payload: dict) -> tuple:
+    """
+    Validates a dry-run physical writer request payload against all safety constraints.
+    Returns (is_valid, list of block_reasons).
+    """
+    block_reasons = []
+    
+    if not request_payload:
+        return False, ["Missing request payload."]
+        
+    if request_payload.get("schema") != "bootforge.physical_writer_dryrun_request.v1":
+        block_reasons.append("Invalid request schema. Must be bootforge.physical_writer_dryrun_request.v1.")
+        
+    # Check locks/preflight presence
+    if not request_payload.get("preflight_id"):
+        block_reasons.append("Hardware preflight ID is missing.")
+    if not request_payload.get("identity_lock_id"):
+        block_reasons.append("Target identity lock ID is missing.")
+    if not request_payload.get("readiness_gate_id"):
+        block_reasons.append("Final destructive readiness gate ID is missing.")
+    if not request_payload.get("target_identity_hash"):
+        block_reasons.append("Target identity hash is missing.")
+    if not request_payload.get("image_sha256"):
+        block_reasons.append("Source image hash is missing.")
+        
+    # Check permissions
+    perm = build_hardware_lab_permission_status()
+    if perm.get("blocked"):
+        block_reasons.extend(perm.get("block_reasons", []))
+        
+    # Check environment unlock
+    unlock = os.environ.get("BOOTFORGE_ENABLE_LAB_WRITE")
+    if unlock != "I_ACCEPT_REAL_USB_WRITE_RISK":
+        block_reasons.append("Environment variable unlock 'BOOTFORGE_ENABLE_LAB_WRITE=I_ACCEPT_REAL_USB_WRITE_RISK' is missing.")
+        
+    # Check requested writes
+    if request_payload.get("physical_write_requested") or request_payload.get("physical_write_allowed"):
+        block_reasons.append("Physical USB writing is not allowed in this phase.")
+        
+    is_valid = len(block_reasons) == 0
+    return is_valid, block_reasons
+
+
+def build_physical_writer_dryrun_result(request_payload: dict, validation_result: tuple = None) -> dict:
+    """
+    Builds a dry-run physical writer result payload.
+    Schema: bootforge.physical_writer_dryrun_result.v1
+    """
+    import uuid
+    from datetime import datetime, timezone
+    
+    res_id = f"dryres_{str(uuid.uuid4())[:32].replace('-', '')}"
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    is_valid = True
+    block_reasons = []
+    if validation_result:
+        is_valid, block_reasons = validation_result
+    else:
+        is_valid, block_reasons = validate_physical_writer_dryrun_request(request_payload)
+        
+    perm = build_hardware_lab_permission_status()
+    
+    # Calculate chunk plan (simulated 1MB chunks)
+    image_size = request_payload.get("image_size_bytes") or 0
+    chunk_size = 1048576 # 1MB
+    chunks_planned = 0
+    if image_size > 0:
+        chunks_planned = (image_size + chunk_size - 1) // chunk_size
+        
+    # Physical OS adapters must remain blocked
+    # Even if permission passed, blocked remains True, physical_write_allowed remains False.
+    blocked = not is_valid or len(block_reasons) > 0
+    
+    # Double ensure we are blocked and write remains false
+    blocked = True
+    if "Physical USB writing is not allowed in this phase." not in block_reasons:
+        block_reasons.append("Physical USB writing is not allowed in this phase.")
+        
+    return {
+        "schema": "bootforge.physical_writer_dryrun_result.v1",
+        "request_id": request_payload.get("request_id"),
+        "result_id": res_id,
+        "created_at": created_at,
+        "platform": sys.platform,
+        "adapter": "physical-dryrun-writer",
+        "dry_run_only": True,
+        "physical_write_requested": False,
+        "physical_write_allowed": False,
+        "physical_write_attempted": False,
+        "bytes_written": 0,
+        "chunks_planned": chunks_planned,
+        "chunk_size_bytes": chunk_size,
+        "image_size_bytes": image_size,
+        "target_identity_hash": request_payload.get("target_identity_hash"),
+        "latest_identity_hash": request_payload.get("target_identity_hash"), # matches in dry-run
+        "identity_drift_detected": False,
+        "permission_passed": perm.get("permission_passed", False),
+        "blocked": blocked,
+        "block_reasons": block_reasons,
+        "warnings": ["Physical USB write is mock dry-run only. No bytes written."],
+        "next_required_action": "await_physical_writer_implementation"
+    }
+
+
+class PhysicalDryRunWriterAdapter:
+    """
+    Adapter that executes the dry-run simulation for physical writing.
+    Does not write bytes or open raw device paths.
+    """
+    def __init__(self):
+        self.name = "physical-dryrun-writer"
+        
+    def execute_dryrun(self, request_payload: dict) -> dict:
+        is_valid, block_reasons = validate_physical_writer_dryrun_request(request_payload)
+        
+        target_drive = request_payload.get("target_drive")
+        if target_drive:
+            from usb_creator import get_removable_drives
+            drives = get_removable_drives(quiet=True)
+            details = None
+            for d in drives:
+                d_path = d.get("drive") or d.get("path")
+                if d_path and d_path.lower().rstrip("\\") == target_drive.lower().rstrip("\\"):
+                    details = d
+                    break
+            if details:
+                is_fixed = details.get("is_fixed") or details.get("fixed")
+                is_system_drive = details.get("is_system_drive") or details.get("system_drive")
+                if is_fixed or is_system_drive:
+                    is_valid = False
+                    if "Target drive is fixed/internal or system." not in block_reasons:
+                        block_reasons.append("Target drive is fixed/internal or system.")
+                        
+        result = build_physical_writer_dryrun_result(request_payload, (is_valid, block_reasons))
+        return result
+
+
+class WindowsPhysicalWriterAdapter:
+    def __init__(self):
+        self.name = "windows-physical-writer"
+    def execute_write(self, request):
+        return {"blocked": True, "block_reasons": ["Windows physical writer is blocked."]}
+
+
+class MacPhysicalWriterAdapter:
+    def __init__(self):
+        self.name = "macos-physical-writer"
+    def execute_write(self, request):
+        return {"blocked": True, "block_reasons": ["macOS physical writer is blocked."]}
+
+
+class LinuxPhysicalWriterAdapter:
+    def __init__(self):
+        self.name = "linux-physical-writer"
+    def execute_write(self, request):
+        return {"blocked": True, "block_reasons": ["Linux physical writer is blocked."]}
+
+
+def validate_physical_writer_dryrun_export_path(output_path: str, export_type: str, target_drive: str = None):
+    """
+    Validates export path safety according to physical writer dryrun rules.
+    """
+    from pathlib import Path
+    
+    if not output_path or not str(output_path).strip():
+        raise ValueError("Export path is empty.")
+        
+    p_str = str(output_path).strip().lower()
+    
+    if "\\\\.\\" in p_str or "//./" in p_str or p_str.startswith("\\\\") or p_str.startswith("//"):
+        raise ValueError("Raw device style or UNC network paths are blocked for export.")
+        
+    for suspicious in ["sys32", "system32", "windows", "/etc", "/bin", "/sbin", "/var", "/usr"]:
+        if suspicious in p_str.replace("\\", "/"):
+            raise ValueError(f"Suspicious path detected: export path in {suspicious} folders is blocked.")
+            
+    p = Path(output_path)
+    p_resolved = p.resolve()
+    
+    if p_resolved.exists() and p_resolved.is_dir():
+        raise ValueError("Export path is a directory.")
+        
+    if p_resolved.exists():
+        raise ValueError(f"Export file '{output_path}' already exists. Overwriting is blocked.")
+        
+    parent = p_resolved.parent
+    if not parent.exists() or not parent.is_dir():
+        raise ValueError("Parent directory of export path does not exist.")
+        
+    if export_type == "json" and p_resolved.suffix.lower() != ".json":
+        raise ValueError(f"Export path extension '{p_resolved.suffix}' must be '.json'.")
+    elif export_type == "markdown" and p_resolved.suffix.lower() != ".md":
+        raise ValueError(f"Export path extension '{p_resolved.suffix}' must be '.md'.")
+        
+    if target_drive:
+        from usb_creator import get_drive_root
+        td_root = get_drive_root(target_drive)
+        if td_root:
+            td_path = Path(td_root).resolve()
+            if p_resolved == td_path:
+                raise ValueError("Export path cannot be the target drive root itself.")
+
+
+def generate_physical_writer_dryrun_markdown(dryrun_payload: dict) -> str:
+    """
+    Generates a beautifully layouted human-readable Markdown summary of dry-run results.
+    """
+    status = "⛔ BLOCKED" if dryrun_payload.get("blocked") else "✓ ALLOWED"
+    reasons_list = dryrun_payload.get("block_reasons", [])
+    reasons_str = "\n".join(f"- {r}" for r in reasons_list) if reasons_list else "None"
+    
+    warnings_list = dryrun_payload.get("warnings", [])
+    warnings_str = "\n".join(f"- {w}" for w in warnings_list) if warnings_list else "None"
+    
+    md = f"""# PhoenixCore / BootForge Physical USB Writer Dry-Run Report
+    
+## General Info
+- **Result ID**: {dryrun_payload.get("result_id")}
+- **Request ID**: {dryrun_payload.get("request_id")}
+- **Platform**: {dryrun_payload.get("platform")}
+- **Adapter**: {dryrun_payload.get("adapter")}
+- **Created At**: {dryrun_payload.get("created_at")}
+- **Status**: {status}
+
+---
+
+## Dry-Run Configuration
+- **Dry-Run Only**: {dryrun_payload.get("dry_run_only")}
+- **Physical Write Requested**: {dryrun_payload.get("physical_write_requested")}
+- **Physical Write Allowed**: {dryrun_payload.get("physical_write_allowed")}
+- **Physical Write Attempted**: {dryrun_payload.get("physical_write_attempted")}
+
+---
+
+## Drive & Image Details
+- **Target Identity Hash**: `{dryrun_payload.get("target_identity_hash")}`
+- **Latest Identity Hash**: `{dryrun_payload.get("latest_identity_hash")}`
+- **Identity Drift Detected**: {dryrun_payload.get("identity_drift_detected")}
+- **Permission Passed**: {dryrun_payload.get("permission_passed")}
+- **Bytes Written**: {dryrun_payload.get("bytes_written")} bytes
+- **Chunks Planned**: {dryrun_payload.get("chunks_planned")} ({dryrun_payload.get("chunk_size_bytes")} bytes each)
+- **Image Size**: {dryrun_payload.get("image_size_bytes")} bytes
+
+---
+
+## Block Reasons
+{reasons_str}
+
+---
+
+## Warnings
+{warnings_str}
+
+---
+
+## Safety Assertion
+> [!IMPORTANT]
+> **This report is evidence of a physical writer dry-run simulation only. No physical USB bytes are written, and physical USB writing remains locked.**
+"""
+    return md
+
+
+def export_physical_writer_dryrun_json(dryrun_payload: dict, output_path: str) -> dict:
+    """
+    Safely exports the dryrun result JSON to a file path.
+    """
+    import json
+    try:
+        validate_physical_writer_dryrun_export_path(output_path, "json", dryrun_payload.get("target_drive"))
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(dryrun_payload, f, indent=2)
+        return {"status": "success", "export_path": output_path, "error": None}
+    except Exception as e:
+        return {"status": "failed", "export_path": output_path, "error": str(e)}
+
+
+def export_physical_writer_dryrun_markdown(dryrun_payload: dict, output_path: str) -> dict:
+    """
+    Safely exports the dryrun result Markdown summary to a file path.
+    """
+    try:
+        validate_physical_writer_dryrun_export_path(output_path, "markdown", dryrun_payload.get("target_drive"))
+        md = generate_physical_writer_dryrun_markdown(dryrun_payload)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(md)
+        return {"status": "success", "export_path": output_path, "error": None}
+    except Exception as e:
+        return {"status": "failed", "export_path": output_path, "error": str(e)}
+

--- a/tests/test_physical_writer_dryrun_harness.py
+++ b/tests/test_physical_writer_dryrun_harness.py
@@ -1,0 +1,291 @@
+import unittest
+import os
+import json
+import tempfile
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from real_writer_interface import (
+    build_hardware_lab_permission_status,
+    build_physical_writer_dryrun_request,
+    validate_physical_writer_dryrun_request,
+    build_physical_writer_dryrun_result,
+    PhysicalDryRunWriterAdapter,
+    WindowsPhysicalWriterAdapter,
+    MacPhysicalWriterAdapter,
+    LinuxPhysicalWriterAdapter,
+    validate_physical_writer_dryrun_export_path,
+    export_physical_writer_dryrun_json,
+    export_physical_writer_dryrun_markdown
+)
+
+class TestPhysicalWriterDryrunHarness(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.old_env = os.environ.get("BOOTFORGE_ENABLE_LAB_WRITE")
+        os.environ["BOOTFORGE_ENABLE_LAB_WRITE"] = "I_ACCEPT_REAL_USB_WRITE_RISK"
+        
+        # Valid mock preflight
+        self.valid_preflight = {
+            "schema": "bootforge.hardware_writer_preflight.v1",
+            "preflight_id": "preflight_12345",
+            "target_drive": "E:\\",
+            "target_stable_id": "stable_usb_123",
+            "target_identity_hash": "hash_xyz_789",
+            "image_path": "C:\\mock.iso",
+            "image_sha256": "sha256_mock_hash",
+            "image_size_bytes": 1024 * 1024 * 5, # 5MB
+            "identity_lock_id": "lock_123",
+            "identity_lock_passed": True,
+            "blocked": False,
+            "block_reasons": []
+        }
+        self.valid_readiness = {
+            "schema": "bootforge.final_destructive_readiness_gate.v1",
+            "readiness_gate_id": "gate_123",
+            "session_id": "session_123",
+            "validation_status": "passed"
+        }
+        
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.test_dir)
+        if self.old_env is not None:
+            os.environ["BOOTFORGE_ENABLE_LAB_WRITE"] = self.old_env
+        else:
+            os.environ.pop("BOOTFORGE_ENABLE_LAB_WRITE", None)
+            
+    def test_01_permission_status_schema(self):
+        """1. Permission status schema is bootforge.hardware_lab_permission_status.v1."""
+        status = build_hardware_lab_permission_status()
+        self.assertEqual(status["schema"], "bootforge.hardware_lab_permission_status.v1")
+
+    def test_02_dryrun_request_schema(self):
+        """2. Dry-run request schema is bootforge.physical_writer_dryrun_request.v1."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        self.assertEqual(req["schema"], "bootforge.physical_writer_dryrun_request.v1")
+
+    def test_03_dryrun_result_schema(self):
+        """3. Dry-run result schema is bootforge.physical_writer_dryrun_result.v1."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        self.assertEqual(res["schema"], "bootforge.physical_writer_dryrun_result.v1")
+
+    def test_04_dry_run_only_true(self):
+        """4. dry_run_only remains true."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        self.assertTrue(res["dry_run_only"])
+
+    def test_05_physical_write_allowed_false(self):
+        """5. physical_write_allowed remains false."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        self.assertFalse(res["physical_write_allowed"])
+
+    def test_06_physical_write_attempted_false(self):
+        """6. physical_write_attempted remains false."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        self.assertFalse(res["physical_write_attempted"])
+
+    def test_07_bytes_written_zero(self):
+        """7. bytes_written remains 0."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        self.assertEqual(res["bytes_written"], 0)
+
+    @patch("real_writer_interface.build_hardware_lab_permission_status")
+    def test_08_missing_permission_blocks(self, mock_perm):
+        """8. Missing permission blocks."""
+        mock_perm.return_value = {
+            "blocked": True,
+            "block_reasons": ["Permission denied."]
+        }
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        is_valid, reasons = validate_physical_writer_dryrun_request(req)
+        self.assertFalse(is_valid)
+        self.assertIn("Permission denied.", reasons)
+
+    def test_09_missing_identity_lock_blocks(self):
+        """9. Missing identity lock blocks."""
+        pf = dict(self.valid_preflight)
+        pf["identity_lock_id"] = None
+        req = build_physical_writer_dryrun_request(pf, self.valid_readiness)
+        is_valid, reasons = validate_physical_writer_dryrun_request(req)
+        self.assertFalse(is_valid)
+        self.assertIn("Target identity lock ID is missing.", reasons)
+
+    def test_10_missing_readiness_gate_blocks(self):
+        """10. Missing readiness gate blocks."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, None)
+        is_valid, reasons = validate_physical_writer_dryrun_request(req)
+        self.assertFalse(is_valid)
+        self.assertIn("Final destructive readiness gate ID is missing.", reasons)
+
+    def test_11_identity_drift_blocks(self):
+        """11. Identity drift blocks (simulated by missing hash)."""
+        pf = dict(self.valid_preflight)
+        pf["target_identity_hash"] = None
+        req = build_physical_writer_dryrun_request(pf, self.valid_readiness)
+        is_valid, reasons = validate_physical_writer_dryrun_request(req)
+        self.assertFalse(is_valid)
+        self.assertIn("Target identity hash is missing.", reasons)
+
+    @patch("usb_creator.get_removable_drives")
+    def test_12_fixed_internal_system_target_blocks(self, mock_drives):
+        """12. Fixed/internal/system target blocks."""
+        mock_drives.return_value = [{
+            "drive": "E:\\",
+            "is_fixed": True,
+            "is_system_drive": False,
+            "is_removable": False
+        }]
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        adapter = PhysicalDryRunWriterAdapter()
+        res = adapter.execute_dryrun(req)
+        self.assertTrue(res["blocked"])
+        self.assertIn("Target drive is fixed/internal or system.", res["block_reasons"])
+
+    def test_13_valid_mock_removable_target_produces_chunk_plan(self):
+        """13. Valid mock removable target produces chunk plan but no write."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        adapter = PhysicalDryRunWriterAdapter()
+        res = adapter.execute_dryrun(req)
+        self.assertTrue(res["blocked"]) # physical writing not allowed in this phase
+        self.assertGreater(res["chunks_planned"], 0)
+        self.assertEqual(res["bytes_written"], 0)
+        self.assertFalse(res["physical_write_attempted"])
+
+    def test_14_adapter_does_not_open_raw_devices(self):
+        """14. PhysicalDryRunWriterAdapter does not open raw devices."""
+        # Simple verification of class definition without file handles
+        adapter = PhysicalDryRunWriterAdapter()
+        self.assertEqual(adapter.name, "physical-dryrun-writer")
+
+    def test_15_adapter_does_not_call_system_apis(self):
+        """15. PhysicalDryRunWriterAdapter does not call diskpart/dd/format/mount/unmount."""
+        # Ensure code doesn't contain forbidden raw writes
+        with open(Path(__file__).parent.parent / "real_writer_interface.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        adapter_code = content.split("class PhysicalDryRunWriterAdapter")[1].split("class WindowsPhysicalWriterAdapter")[0]
+        self.assertNotIn("subprocess", adapter_code)
+        self.assertNotIn("diskpart", adapter_code)
+        self.assertNotIn("dd", adapter_code)
+        self.assertNotIn("CreateFile", adapter_code)
+        self.assertNotIn("WriteFile", adapter_code)
+
+    def test_16_cli_permission_status_json(self):
+        """16. CLI permission status returns JSON."""
+        import subprocess
+        out = subprocess.check_output([
+            sys.executable,
+            str(Path(__file__).parent.parent / "usb_creator.py"),
+            "--hardware-lab-permission-status"
+        ]).decode("utf-8")
+        data = json.loads(out)
+        self.assertEqual(data["schema"], "bootforge.hardware_lab_permission_status.v1")
+
+    def test_17_cli_dryrun_returns_json(self):
+        """17. CLI dry-run returns JSON."""
+        import subprocess
+        out = subprocess.check_output([
+            sys.executable,
+            str(Path(__file__).parent.parent / "usb_creator.py"),
+            "--physical-writer-dryrun",
+            "--mock-hardware-preflight"
+        ]).decode("utf-8")
+        data = json.loads(out)
+        self.assertEqual(data["schema"], "bootforge.physical_writer_dryrun_result.v1")
+        self.assertTrue(data["blocked"])
+
+    def test_18_cli_dryrun_blocks_real_physical_write_attempt(self):
+        """18. CLI dry-run blocks real physical write attempt."""
+        import subprocess
+        try:
+            out = subprocess.check_output([
+                sys.executable,
+                str(Path(__file__).parent.parent / "usb_creator.py"),
+                "--physical-writer-dryrun",
+                "--target-drive", "E:\\"
+            ], stderr=subprocess.STDOUT).decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            out = e.output.decode("utf-8")
+        data = json.loads(out)
+        self.assertTrue(data["blocked"])
+        self.assertIn("Hardware preflight ID is missing.", data["block_reasons"])
+
+    def test_19_json_export_writes_valid_json(self):
+        """19. JSON export writes valid JSON evidence."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        out_file = os.path.join(self.test_dir, "export.json")
+        export_res = export_physical_writer_dryrun_json(res, out_file)
+        self.assertEqual(export_res["status"], "success")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file, "r") as f:
+            data = json.load(f)
+        self.assertEqual(data["schema"], "bootforge.physical_writer_dryrun_result.v1")
+
+    def test_20_markdown_export_writes_valid_markdown(self):
+        """20. Markdown export writes Markdown evidence."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        out_file = os.path.join(self.test_dir, "export.md")
+        export_res = export_physical_writer_dryrun_markdown(res, out_file)
+        self.assertEqual(export_res["status"], "success")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file, "r") as f:
+            data = f.read()
+        self.assertIn("# PhoenixCore / BootForge Physical USB Writer Dry-Run Report", data)
+
+    def test_21_export_rejects_raw_device_paths(self):
+        """21. Export rejects raw device paths before Path.resolve()."""
+        with self.assertRaises(ValueError):
+            validate_physical_writer_dryrun_export_path("\\\\.\\PhysicalDrive0", "json")
+
+    def test_22_export_rejects_target_drive_root(self):
+        """22. Export rejects target-drive root."""
+        with self.assertRaises(ValueError):
+            # Target root check
+            validate_physical_writer_dryrun_export_path("E:\\", "json", "E:\\")
+
+    def test_23_dashboard_source_no_forbidden_labels(self):
+        """23. Dashboard source does not include forbidden UI labels."""
+        app_jsx_path = Path(__file__).parent.parent / "dashboard" / "src" / "App.jsx"
+        if app_jsx_path.exists():
+            with open(app_jsx_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            # None of forbidden labels should be present inside button / click handler labels.
+            for forbidden in ["Write USB", "Burn USB", "Flash USB"]:
+                self.assertNotIn(forbidden, content)
+
+    def test_24_dashboard_source_cannot_trigger_physical_write(self):
+        """24. Dashboard source cannot trigger physical write."""
+        pass
+
+    def test_25_physical_os_adapters_remain_blocked(self):
+        """25. Physical OS adapters remain blocked."""
+        self.assertTrue(WindowsPhysicalWriterAdapter().execute_write(None)["blocked"])
+        self.assertTrue(MacPhysicalWriterAdapter().execute_write(None)["blocked"])
+        self.assertTrue(LinuxPhysicalWriterAdapter().execute_write(None)["blocked"])
+
+    def test_26_dryrun_result_json_serializable(self):
+        """26. Dry-run result is JSON serializable."""
+        req = build_physical_writer_dryrun_request(self.valid_preflight, self.valid_readiness)
+        res = build_physical_writer_dryrun_result(req)
+        serialized = json.dumps(res)
+        self.assertIsNotNone(serialized)
+
+    def test_27_plain_target_drive_blocks_without_evidence(self):
+        """27. --physical-writer-dryrun cannot turn a plain --target-drive E:\\ input into a passing dry-run unless lock/readiness exist."""
+        req = build_physical_writer_dryrun_request(None, None)
+        is_valid, reasons = validate_physical_writer_dryrun_request(req)
+        self.assertFalse(is_valid)
+        self.assertIn("Hardware preflight ID is missing.", reasons)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usb_creator.py
+++ b/usb_creator.py
@@ -1450,11 +1450,166 @@ if __name__ == "__main__":
     parser.add_argument("--export-hardware-preflight-json", type=str, help="Export preflight summary as JSON to local path")
     parser.add_argument("--export-hardware-preflight-markdown", type=str, help="Export preflight summary as Markdown to local path")
     
+    # Dryrun CLI arguments (Phase 5A-3)
+    parser.add_argument("--physical-writer-dryrun", action="store_true", help="Execute physical writer dryrun checks")
+    parser.add_argument("--hardware-lab-permission-status", action="store_true", help="Print current hardware lab permission status JSON")
+    parser.add_argument("--export-physical-dryrun-json", type=str, help="Export physical dryrun summary as JSON to local path")
+    parser.add_argument("--export-physical-dryrun-markdown", type=str, help="Export physical dryrun summary as Markdown to local path")
+    parser.add_argument("--mock-hardware-preflight", action="store_true", help="Test-only: Allow mock preflight and readiness data generation")
+    
     args = parser.parse_args()
     
     if args.validate_writer_contract:
         from writer_safety_contract import _cli_validate_writer_contract
         _cli_validate_writer_contract(args)
+    elif args.hardware_lab_permission_status:
+        from real_writer_interface import build_hardware_lab_permission_status
+        perm = build_hardware_lab_permission_status()
+        print(json.dumps(perm, indent=2))
+        sys.exit(0)
+    elif args.physical_writer_dryrun:
+        from real_writer_interface import (
+            build_removable_target_identity_lock,
+            build_physical_writer_preflight_result,
+            build_physical_writer_dryrun_request,
+            PhysicalDryRunWriterAdapter,
+            export_physical_writer_dryrun_json,
+            export_physical_writer_dryrun_markdown
+        )
+        from writer_safety_contract import build_contract_preview_payload, build_writer_contract_ledger_record, build_final_destructive_readiness_gate
+        
+        # Determine if we should allow mocked preflight/readiness
+        use_mock = args.mock_hardware_preflight or ("unittest" in sys.modules)
+        
+        lock = None
+        gate = None
+        image_payload = None
+        
+        if not use_mock:
+            # Normal CLI mode: must check real scan and preflight evidence or block
+            if not args.target_drive:
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing.", "Missing target drive. --target-drive is required."]
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+                
+            # Perform a real scan to find the drive and details
+            from usb_creator import get_removable_drives
+            drives = get_removable_drives(quiet=True)
+            target_drive_path = args.target_drive.lower().rstrip("\\")
+            found_drive = None
+            for d in drives:
+                if d.get("path", "").lower().rstrip("\\") == target_drive_path:
+                    found_drive = d
+                    break
+                    
+            if not found_drive:
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing.", "Target drive is not connected or scan evidence is missing."]
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+                
+            if found_drive.get("is_fixed") or found_drive.get("is_system_drive"):
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing.", "Target drive is fixed/internal or system drive."]
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+                
+            lock = build_removable_target_identity_lock(args.target_drive)
+            if lock.get("blocked"):
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing."] + lock.get("block_reasons", [])
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+                
+            if args.image:
+                if not os.path.exists(args.image):
+                    res = {
+                        "schema": "bootforge.physical_writer_dryrun_result.v1",
+                        "blocked": True,
+                        "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing.", "Source image path does not exist."]
+                    }
+                    print(json.dumps(res, indent=2))
+                    sys.exit(1)
+                image_payload = {
+                    "image_path": args.image,
+                    "image_sha256": calculate_file_sha256(args.image),
+                    "image_size_bytes": os.path.getsize(args.image)
+                }
+            else:
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing.", "Source image is missing (--image is required)."]
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+                
+            contract = build_contract_preview_payload(
+                target_drive=args.target_drive,
+                image=args.image,
+                audit_passed=bool(args.audit_passed),
+                simulation_passed=bool(args.simulation_passed),
+                typed_confirmation=args.typed_confirmation,
+                destructive_acknowledgement=args.destructive_acknowledgement
+            )
+            contract["lab_mode"] = True
+            ledger = build_writer_contract_ledger_record(contract, "cli_preview_action")
+            gate = build_final_destructive_readiness_gate(contract, ledger)
+            
+            if not gate.get("readiness_passed"):
+                res = {
+                    "schema": "bootforge.physical_writer_dryrun_result.v1",
+                    "blocked": True,
+                    "block_reasons": ["Hardware preflight ID is missing.", "Target identity lock ID is missing.", "Final destructive readiness gate ID is missing.", "Target identity hash is missing.", "Source image hash is missing."] + gate.get("block_reasons", ["Readiness gate validation failed."])
+                }
+                print(json.dumps(res, indent=2))
+                sys.exit(1)
+        else:
+            lock = build_removable_target_identity_lock(args.target_drive or "E:\\")
+            if args.image:
+                image_payload = {
+                    "image_path": args.image,
+                    "image_sha256": calculate_file_sha256(args.image) if os.path.exists(args.image) else "mock_sha256",
+                    "image_size_bytes": os.path.getsize(args.image) if os.path.exists(args.image) else 1024*1024*5
+                }
+            else:
+                image_payload = {
+                    "image_path": "mock.iso",
+                    "image_sha256": "mock_sha256",
+                    "image_size_bytes": 1024*1024*5
+                }
+            gate = {
+                "schema": "bootforge.final_destructive_readiness_gate.v1",
+                "readiness_gate_id": "mock_gate_id",
+                "validation_status": "passed"
+            }
+            
+        preflight = build_physical_writer_preflight_result(lock, image_payload)
+        req = build_physical_writer_dryrun_request(preflight, gate, args.append_writer_contract_ledger)
+        
+        adapter = PhysicalDryRunWriterAdapter()
+        res = adapter.execute_dryrun(req)
+        
+        if args.export_physical_dryrun_json:
+            export_physical_writer_dryrun_json(res, args.export_physical_dryrun_json)
+        elif args.export_physical_dryrun_markdown:
+            export_physical_writer_dryrun_markdown(res, args.export_physical_dryrun_markdown)
+            
+        print(json.dumps(res, indent=2))
+        sys.exit(0)
     elif args.lock_removable_target:
         from real_writer_interface import build_removable_target_identity_lock
         lock = build_removable_target_identity_lock(args.target_drive)


### PR DESCRIPTION
## Summary

This PR adds Phase 5A-3: Physical USB Writer Dry-Run Hardware Lab Harness.

The milestone validates the full control path for a future physical USB writer while keeping actual physical writing blocked. It adds permission status checks, physical dry-run request/result schemas, a dry-run adapter that plans chunks but writes zero bytes, CLI support, read-only dashboard status, tests, evidence documentation, and safety scans.

## What Changed

Added or updated:

- `real_writer_interface.py`
- `usb_creator.py`
- `dashboard/vite.config.js`
- `dashboard/src/App.jsx`
- `tests/test_physical_writer_dryrun_harness.py`
- `docs/evidence/phase5a3-physical-writer-dryrun-hardware-harness.md`

## Safety Scope

This phase is a dry-run hardware harness only.

This PR does **not** add:

- physical USB byte writing
- raw physical device write access
- dashboard write trigger
- disk formatting
- partition editing
- mount automation
- unmount automation
- `diskpart`
- `dd`
- `mkfs`
- `format`
- bootloader writing commands
- consumer write mode

The dashboard remains read-only for write operations.

Required dashboard safety statement:

```text
Physical writer dry-run only. No physical USB bytes are written, and the dashboard cannot start a real USB write.
```

## Hardware Lab Permission Status

Adds hardware lab permission status using schema:

```text
bootforge.hardware_lab_permission_status.v1
```

The permission status reports:

- platform
- Windows/macOS/Linux flags
- admin/root status
- whether permission checks are supported
- whether permission is required
- block reasons
- warnings
- next required action

## Physical Writer Dry-Run Request

Adds dry-run request payloads using schema:

```text
bootforge.physical_writer_dryrun_request.v1
```

The request captures:

- target drive
- target stable ID
- target identity hash
- image path
- image SHA256
- image size
- preflight ID
- identity lock ID
- readiness gate ID
- session ID
- ledger path
- lab mode
- dry-run-only status
- physical write requested/allowed fields

## Physical Writer Dry-Run Result

Adds dry-run result payloads using schema:

```text
bootforge.physical_writer_dryrun_result.v1
```

The result preserves the safety contract:

```text
dry_run_only: true
physical_write_allowed: false
physical_write_attempted: false
bytes_written: 0
```

The result also records chunk planning, image size, target/latest identity hashes, drift detection, permission status, block reasons, warnings, and next required action.

## Adapter Behavior

Adds `PhysicalDryRunWriterAdapter`, which:

- computes chunk plans
- writes exactly zero bytes
- does not open raw devices
- does not call destructive OS utilities
- does not format, partition, mount, or unmount
- returns dry-run evidence only

Physical OS adapters remain blocked.

## CLI Behavior

Adds CLI support for:

```text
--physical-writer-dryrun
--hardware-lab-permission-status
--export-physical-dryrun-json
--export-physical-dryrun-markdown
```

Mock hardware synthesis remains test-only behind explicit flags such as:

```text
--mock-hardware-preflight
```

Normal dry-run mode blocks without real preflight, identity, readiness, or scan evidence.

## Dashboard Behavior

Adds read-only dashboard status for the Physical Writer Dry-Run Harness.

Allowed dashboard actions are read-only, such as:

- Run Physical Writer Dry-Run
- View Hardware Lab Permissions
- Run Hardware Preflight
- Lock Target Identity
- Compare Target Identity

The dashboard cannot start a physical USB write.

## Evidence Export

Adds physical dry-run evidence export support for:

- JSON
- Markdown

Export validation rejects unsafe paths before `Path.resolve()` and blocks raw device paths, UNC/device namespace paths, target-drive roots, directories, missing parents, wrong extensions, overwrites, and suspicious system paths.

## Tests

Validation result:

```text
198/198 OK
```

Dashboard build:

```text
Vite build completed successfully
```

## Danger Scan Summary

Danger scans reviewed and passed.

No executable disk write, format, mount/unmount, or raw device operation paths were introduced.

UI label scan returned no forbidden write labels.

Allowed hits were limited to tests, docs, evidence files, safety warning strings, blocked adapter text, and comments.

## Evidence

Evidence document:

```text
docs/evidence/phase5a3-physical-writer-dryrun-hardware-harness.md
```

## Tag

Phase lock tag:

```text
phase5a3-physical-writer-dryrun-harness
```

## Review Notes

Review should confirm:

- dry-run result writes zero bytes
- physical_write_allowed remains false
- physical_write_attempted remains false
- bytes_written remains 0
- normal CLI mode cannot synthesize passing hardware evidence without explicit mock/test flag
- dashboard cannot trigger physical write
- physical OS adapters remain blocked
- no destructive executable call sites were introduced