### PR TITLE
Phase 5B-1: Cross-Platform Device Scanner Consolidation

### DIFF
--- a/device_scanner.py
+++ b/device_scanner.py
@@ -1,0 +1,486 @@
+"""
+device_scanner.py
+PhoenixCore / BootForge USB Creator
+Cross-Platform Device Scanner
+
+Read-only, non-destructive removable device detection for Windows, macOS, and Linux.
+This module only reads device metadata. It never writes to, alters, or accesses any drive.
+No destructive operations or raw-device APIs exist in this module.
+
+Detection sources:
+  Windows  — PowerShell Get-CimInstance Win32_DiskDrive
+  macOS    — diskutil list -plist / diskutil info -plist
+  Linux    — /sys/block sysfs + udevadm info
+  Fallback — lsblk -J (Linux) or degraded result
+"""
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCANNER_SCHEMA = "bootforge.device_scan.v2"
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _human_size(size_bytes):
+    if size_bytes is None or size_bytes <= 0:
+        return "0 B"
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} PB"
+
+
+def _build_device_record(**kwargs):
+    warnings = kwargs.get("warnings") or []
+    block_reasons = kwargs.get("block_reasons") or []
+
+    is_fixed = kwargs.get("is_fixed", False)
+    is_system = kwargs.get("is_system", False)
+    is_removable = kwargs.get("is_removable", False)
+    serial = kwargs.get("serial")
+    stable_id = kwargs.get("stable_id")
+    size_bytes = kwargs.get("size_bytes", 0)
+
+    confidence = "high"
+    if not serial and not stable_id:
+        confidence = "low"
+        warnings.append("No serial number or stable ID available; identity lock will be unreliable.")
+    elif not serial:
+        confidence = "medium"
+        warnings.append("No serial number available; using stable ID only.")
+
+    if is_system:
+        block_reasons.append("Drive is a system/boot drive.")
+    if is_fixed and not is_removable:
+        block_reasons.append("Drive is fixed/internal, not removable.")
+    if size_bytes <= 0:
+        block_reasons.append("Drive reports zero or unknown size.")
+
+    is_eligible = is_removable and not is_system and not is_fixed and len(block_reasons) == 0
+
+    return {
+        "drive_path": kwargs.get("drive_path"),
+        "display_name": kwargs.get("display_name") or kwargs.get("drive_path") or "Unknown",
+        "stable_id": stable_id,
+        "serial": serial,
+        "size_bytes": size_bytes,
+        "size_gb": round(size_bytes / (1024 ** 3), 2) if size_bytes > 0 else 0.0,
+        "size_human": _human_size(size_bytes),
+        "filesystem": kwargs.get("filesystem"),
+        "volume_label": kwargs.get("volume_label"),
+        "is_removable": is_removable,
+        "is_external": kwargs.get("is_external", False),
+        "is_fixed": is_fixed,
+        "is_system": is_system,
+        "bus_protocol": kwargs.get("bus_protocol"),
+        "platform": kwargs.get("platform") or sys.platform,
+        "detection_source": kwargs.get("detection_source") or "unknown",
+        "confidence": confidence,
+        "is_eligible": is_eligible,
+        "warnings": warnings,
+        "block_reasons": block_reasons,
+    }
+
+
+def _run_command(cmd, timeout=10):
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return -1, "", f"Command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -2, "", f"Command timed out after {timeout}s: {' '.join(cmd)}"
+    except Exception as e:
+        return -3, "", str(e)
+
+
+def _run_command_bytes(cmd, timeout=10):
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=False,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return -1, b"", f"Command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -2, b"", f"Command timed out after {timeout}s: {' '.join(cmd)}"
+    except Exception as e:
+        return -3, b"", str(e)
+
+
+# ---------------------------------------------------------------------------
+# Windows scanner — PowerShell Get-CimInstance Win32_DiskDrive
+# ---------------------------------------------------------------------------
+
+WINDOWS_PS_SCRIPT = (
+    "Get-CimInstance Win32_DiskDrive | "
+    "Select-Object DeviceID, Model, SerialNumber, Size, MediaType, "
+    "InterfaceType, Partitions, Status, Caption | ConvertTo-Json"
+)
+
+
+def parse_windows_scan_output(raw_json):
+    devices = []
+    if not raw_json or not raw_json.strip():
+        return devices
+
+    try:
+        data = json.loads(raw_json)
+    except (json.JSONDecodeError, ValueError):
+        return devices
+
+    if isinstance(data, dict):
+        data = [data]
+
+    for item in data:
+        device_id = item.get("DeviceID") or ""
+        size_bytes = int(item.get("Size") or 0)
+        serial = (item.get("SerialNumber") or "").strip() or None
+        model = (item.get("Model") or "").strip() or None
+        interface = (item.get("InterfaceType") or "").strip()
+        media_type = (item.get("MediaType") or "").strip().lower()
+
+        is_removable = interface in ("USB", "SD", "1394") or "removable" in media_type or "external" in media_type
+        is_fixed = not is_removable and ("fixed" in media_type or interface not in ("USB", "SD", "1394"))
+
+        disk_number = device_id.replace("\\\\.\\PHYSICALDRIVE", "").replace("\\\\.\\PhysicalDrive", "")
+        stable_id = f"win32_disk{disk_number}_{serial}" if serial else None
+
+        devices.append(_build_device_record(
+            drive_path=device_id,
+            display_name=model or f"Disk {disk_number}",
+            stable_id=stable_id,
+            serial=serial,
+            size_bytes=size_bytes,
+            is_removable=is_removable,
+            is_external=is_removable,
+            is_fixed=is_fixed,
+            is_system=False,
+            bus_protocol=interface or None,
+            platform="win32",
+            detection_source="powershell_win32_diskdrive",
+        ))
+
+    return devices
+
+
+def scan_windows():
+    code, stdout, stderr = _run_command(
+        ["powershell", "-NoProfile", "-Command", WINDOWS_PS_SCRIPT],
+        timeout=15,
+    )
+    if code != 0:
+        return [], [f"PowerShell scan failed (code {code}): {stderr}"]
+
+    devices = parse_windows_scan_output(stdout)
+    return devices, []
+
+
+# ---------------------------------------------------------------------------
+# macOS scanner — diskutil list/info -plist
+# ---------------------------------------------------------------------------
+
+def parse_macos_disk_list(plist_bytes):
+    import plistlib
+    try:
+        data = plistlib.loads(plist_bytes)
+    except Exception:
+        return []
+    return data.get("WholeDisks", [])
+
+
+def parse_macos_disk_info(plist_bytes):
+    import plistlib
+    try:
+        return plistlib.loads(plist_bytes)
+    except Exception:
+        return {}
+
+
+def build_macos_device_from_info(disk_id, info):
+    is_removable = info.get("Removable", False) or info.get("RemovableMedia", False)
+    is_external = info.get("External", False)
+    is_internal = info.get("Internal", False)
+    is_system = info.get("SystemImage", False)
+    size_bytes = info.get("TotalSize", 0) or info.get("Size", 0)
+    media_name = info.get("MediaName") or ""
+    volume_name = info.get("VolumeName") or ""
+    filesystem = info.get("FilesystemType") or info.get("Content") or None
+    bus_protocol = info.get("BusProtocol") or info.get("Protocol") or None
+    serial = info.get("IORegistryEntryName") or None
+    device_node = info.get("DeviceNode") or f"/dev/{disk_id}"
+
+    display_name = media_name or volume_name or disk_id
+    stable_id = f"darwin_{disk_id}_{serial}" if serial else None
+
+    return _build_device_record(
+        drive_path=device_node,
+        display_name=display_name,
+        stable_id=stable_id,
+        serial=serial,
+        size_bytes=size_bytes,
+        filesystem=filesystem,
+        volume_label=volume_name or None,
+        is_removable=is_removable or is_external,
+        is_external=is_external,
+        is_fixed=is_internal and not is_removable and not is_external,
+        is_system=is_system,
+        bus_protocol=bus_protocol,
+        platform="darwin",
+        detection_source="diskutil_plist",
+    )
+
+
+def scan_macos():
+    code, stdout_bytes, stderr = _run_command_bytes(
+        ["diskutil", "list", "-plist", "external", "physical"],
+        timeout=10,
+    )
+    if code != 0:
+        code2, stdout_bytes2, stderr2 = _run_command_bytes(
+            ["diskutil", "list", "-plist"],
+            timeout=10,
+        )
+        if code2 != 0:
+            return [], [f"diskutil list failed (code {code2}): {stderr2}"]
+        stdout_bytes = stdout_bytes2
+
+    disk_ids = parse_macos_disk_list(stdout_bytes)
+    if not disk_ids:
+        return [], []
+
+    devices = []
+    scan_warnings = []
+    for disk_id in disk_ids:
+        code, info_bytes, stderr = _run_command_bytes(
+            ["diskutil", "info", "-plist", disk_id],
+            timeout=5,
+        )
+        if code != 0:
+            scan_warnings.append(f"diskutil info failed for {disk_id}: {stderr}")
+            continue
+
+        info = parse_macos_disk_info(info_bytes)
+        if not info:
+            scan_warnings.append(f"Failed to parse plist for {disk_id}")
+            continue
+
+        device = build_macos_device_from_info(disk_id, info)
+        devices.append(device)
+
+    return devices, scan_warnings
+
+
+# ---------------------------------------------------------------------------
+# Linux scanner — /sys/block + udevadm
+# ---------------------------------------------------------------------------
+
+def read_sysfs_file(path):
+    try:
+        p = Path(path)
+        if p.exists():
+            return p.read_text().strip()
+    except Exception:
+        pass
+    return None
+
+
+def parse_udevadm_output(raw_output):
+    props = {}
+    if not raw_output:
+        return props
+    for line in raw_output.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            props[key.strip()] = value.strip()
+    return props
+
+
+def scan_linux_sysblock():
+    block_path = Path("/sys/block")
+    if not block_path.exists():
+        return [], ["No /sys/block found; using fallback."]
+
+    devices = []
+    scan_warnings = []
+
+    try:
+        entries = sorted(block_path.iterdir())
+    except Exception as e:
+        return [], [f"Failed to read /sys/block: {e}"]
+
+    for entry in entries:
+        name = entry.name
+        if name.startswith(("loop", "ram", "zram", "dm-", "md", "sr")):
+            continue
+
+        removable_val = read_sysfs_file(f"/sys/block/{name}/removable")
+        is_removable = removable_val == "1"
+
+        size_str = read_sysfs_file(f"/sys/block/{name}/size")
+        size_bytes = 0
+        if size_str:
+            try:
+                size_bytes = int(size_str) * 512
+            except ValueError:
+                pass
+        if size_bytes <= 0:
+            continue
+
+        vendor = read_sysfs_file(f"/sys/block/{name}/device/vendor") or ""
+        model = read_sysfs_file(f"/sys/block/{name}/device/model") or ""
+
+        serial = read_sysfs_file(f"/sys/block/{name}/device/serial")
+        if not serial:
+            code, stdout, _ = _run_command(
+                ["udevadm", "info", "--query=property", f"--name=/dev/{name}"],
+                timeout=3,
+            )
+            if code == 0:
+                props = parse_udevadm_output(stdout)
+                serial = props.get("ID_SERIAL") or props.get("ID_SERIAL_SHORT")
+
+        is_system = False
+        try:
+            with open("/proc/mounts", "r") as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 2 and parts[1] == "/" and name in parts[0]:
+                        is_system = True
+                        break
+        except Exception:
+            pass
+
+        display_name = f"{vendor} {model}".strip() or name
+        stable_id = f"linux_{name}_{serial}" if serial else None
+
+        devices.append(_build_device_record(
+            drive_path=f"/dev/{name}",
+            display_name=display_name,
+            stable_id=stable_id,
+            serial=serial,
+            size_bytes=size_bytes,
+            is_removable=is_removable,
+            is_external=is_removable,
+            is_fixed=not is_removable,
+            is_system=is_system,
+            bus_protocol=None,
+            platform="linux",
+            detection_source="sysblock_udevadm",
+        ))
+
+    return devices, scan_warnings
+
+
+def scan_linux_lsblk_fallback():
+    code, stdout, stderr = _run_command(["lsblk", "-J", "-o", "NAME,SIZE,RM,LABEL,FSTYPE,MOUNTPOINT"], timeout=10)
+    if code != 0:
+        return [], [f"lsblk fallback failed (code {code}): {stderr}"]
+
+    devices = []
+    try:
+        data = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return [], ["lsblk output is not valid JSON."]
+
+    for blk in data.get("blockdevices", []):
+        name = blk.get("name", "")
+        if name.startswith(("loop", "ram", "zram")):
+            continue
+
+        rm = blk.get("rm")
+        is_removable = rm in ("1", 1, True, "true")
+
+        devices.append(_build_device_record(
+            drive_path=f"/dev/{name}",
+            display_name=name,
+            stable_id=None,
+            serial=None,
+            size_bytes=0,
+            filesystem=blk.get("fstype"),
+            volume_label=blk.get("label"),
+            is_removable=is_removable,
+            is_external=is_removable,
+            is_fixed=not is_removable,
+            is_system=blk.get("mountpoint") == "/",
+            platform="linux",
+            detection_source="lsblk_fallback",
+        ))
+
+    return devices, []
+
+
+def scan_linux():
+    devices, warnings = scan_linux_sysblock()
+    if not devices and not warnings:
+        devices, warnings = scan_linux_lsblk_fallback()
+    return devices, warnings
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def scan_devices(platform_override=None):
+    plat = platform_override or sys.platform
+    scan_id = f"scan_{str(uuid.uuid4())[:12]}"
+    created_at = _utc_now()
+
+    devices = []
+    scan_warnings = []
+    detection_source = "unknown"
+
+    if plat == "win32":
+        devices, scan_warnings = scan_windows()
+        detection_source = "powershell_win32_diskdrive"
+    elif plat == "darwin":
+        devices, scan_warnings = scan_macos()
+        detection_source = "diskutil_plist"
+    elif plat.startswith("linux"):
+        devices, scan_warnings = scan_linux()
+        detection_source = "sysblock_udevadm"
+    else:
+        scan_warnings.append(f"Unsupported platform '{plat}'; no devices detected.")
+
+    return {
+        "schema": SCANNER_SCHEMA,
+        "scan_id": scan_id,
+        "created_at": created_at,
+        "platform": plat,
+        "detection_source": detection_source,
+        "safe_mode": True,
+        "destructive": False,
+        "operation": "read_only_device_scan",
+        "device_count": len(devices),
+        "devices": devices,
+        "scan_warnings": scan_warnings,
+    }
+
+
+def get_device_by_path(scan_result, drive_path):
+    for device in scan_result.get("devices", []):
+        if device.get("drive_path") == drive_path:
+            return device
+    return None
+
+
+def get_eligible_devices(scan_result):
+    return [d for d in scan_result.get("devices", []) if d.get("is_eligible")]

--- a/docs/evidence/phase5b1-cross-platform-device-scanner-consolidation.md
+++ b/docs/evidence/phase5b1-cross-platform-device-scanner-consolidation.md
@@ -1,0 +1,112 @@
+# Phase 5B-1: Cross-Platform Device Scanner Consolidation
+
+## Summary
+
+Introduces `device_scanner.py` — a standalone, read-only, cross-platform device detection module that normalizes removable drive information across Windows, macOS, and Linux into a unified schema (`bootforge.device_scan.v2`).
+
+**No physical writing was added. This module only reads device metadata.**
+
+---
+
+## Source Files Reviewed
+
+| File | Source | What Was Extracted |
+|------|--------|--------------------|
+| `device_scanner.py` (iCloud) | 450 lines, psutil + /sys/block + udevadm | Linux sysfs removable detection, udevadm serial fallback, vendor/model parsing, /proc/mounts system drive check |
+| `bootforge.py` (iCloud) | 333 lines, dry-run-only MVP | macOS `diskutil list -plist external physical` pattern, `diskutil info -plist` field mapping, Windows `Get-CimInstance Win32_DiskDrive` via PowerShell |
+
+### What Was Rejected
+
+- `psutil` dependency — removed; PhoenixCore doesn't require it and the sysfs/udevadm approach is more reliable
+- `app_utils.py` imports — project-specific utility from ChatGPT project, not applicable
+- `_assess_risk()` — replaced with explicit `is_eligible` flag based on safety rules
+- `_get_partitions_linux()` — partition enumeration not needed for this phase
+- `write_speed_mbps`, `health_status` fields — not reliably detectable, removed
+- Logging via `logging.getLogger` — PhoenixCore uses its own `_log()` pattern
+
+---
+
+## Platform Detection Behavior
+
+### Windows (`win32`)
+- PowerShell `Get-CimInstance Win32_DiskDrive` with `-NoProfile`
+- Fields: DeviceID, Model, SerialNumber, Size, MediaType, InterfaceType
+- USB/SD/1394 interface types marked as removable
+- Fixed media types marked as fixed/internal
+
+### macOS (`darwin`)
+- `diskutil list -plist external physical` (falls back to `diskutil list -plist`)
+- `diskutil info -plist <disk_id>` per WholeDisks entry
+- Fields: Removable, RemovableMedia, External, Internal, SystemImage, TotalSize, MediaName, VolumeName, FilesystemType, BusProtocol, IORegistryEntryName
+
+### Linux
+- Primary: `/sys/block/<device>/removable`, `size`, `device/vendor`, `device/model`, `device/serial`
+- Serial fallback: `udevadm info --query=property --name=/dev/<device>` → `ID_SERIAL`
+- System drive check: `/proc/mounts` root mount detection
+- Fallback: `lsblk -J -o NAME,SIZE,RM,LABEL,FSTYPE,MOUNTPOINT`
+
+---
+
+## Safety Behavior
+
+- All detection is read-only subprocess calls or sysfs reads
+- No destructive command call sites exist in the module
+- Command failures return safe degraded results with warnings, never crash
+- Missing serial/stable ID lowers confidence score
+- Fixed/internal/system drives are always marked ineligible with block reasons
+- Zero-size drives are blocked
+- No auto-selection of targets
+- Plain paths not in scan results return None from `get_device_by_path()`
+
+---
+
+## Normalized Output Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `drive_path` | string | OS device path |
+| `display_name` | string | Human-readable name |
+| `stable_id` | string/null | Platform-prefixed stable identifier |
+| `serial` | string/null | Hardware serial number |
+| `size_bytes` | int | Drive capacity |
+| `size_gb` | float | Capacity in GB |
+| `size_human` | string | Human-readable size |
+| `filesystem` | string/null | Detected filesystem |
+| `volume_label` | string/null | Volume label |
+| `is_removable` | bool | Removable media flag |
+| `is_external` | bool | External connection flag |
+| `is_fixed` | bool | Fixed/internal flag |
+| `is_system` | bool | System/boot drive flag |
+| `bus_protocol` | string/null | Connection bus (USB, SCSI, etc.) |
+| `platform` | string | Detecting platform |
+| `detection_source` | string | Detection method used |
+| `confidence` | string | high/medium/low |
+| `is_eligible` | bool | Safe for write operations |
+| `warnings` | list | Non-blocking warnings |
+| `block_reasons` | list | Reasons drive is ineligible |
+
+---
+
+## Test Results
+
+- **37/37 tests pass** in `tests/test_device_scanner.py`
+- Tests cover: Windows PS parsing (multi/single/empty), macOS plist parsing (removable/system/invalid), Linux udevadm parsing, device record normalization, confidence levels, eligibility rules, command failure safety, ambiguous target blocking, destructive call site scan, dashboard forbidden label scan
+
+## Dashboard Build
+
+- Passed (no dashboard changes in this phase)
+
+## Danger Scan
+
+- `device_scanner.py`: No hits for destructive commands
+- `dashboard/src/App.jsx`: No forbidden UI labels
+
+---
+
+## Explicit Safety Statements
+
+- No physical writing was added in this phase
+- No destructive disk operations exist in `device_scanner.py`
+- Dashboard was not modified
+- Dashboard cannot start physical writes
+- Fixed, internal, and system drives are always marked ineligible

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -1,0 +1,493 @@
+import unittest
+import json
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from device_scanner import (
+    SCANNER_SCHEMA,
+    _build_device_record,
+    _human_size,
+    parse_windows_scan_output,
+    parse_macos_disk_list,
+    parse_macos_disk_info,
+    build_macos_device_from_info,
+    read_sysfs_file,
+    parse_udevadm_output,
+    scan_linux_sysblock,
+    scan_devices,
+    get_device_by_path,
+    get_eligible_devices,
+)
+
+
+MOCK_WINDOWS_PS_OUTPUT = json.dumps([
+    {
+        "DeviceID": "\\\\.\\PHYSICALDRIVE1",
+        "Model": "Kingston DataTraveler 3.0 USB Device",
+        "SerialNumber": "KT123456789",
+        "Size": 15728640000,
+        "MediaType": "Removable Media",
+        "InterfaceType": "USB",
+        "Partitions": 1,
+        "Status": "OK",
+        "Caption": "Kingston DataTraveler 3.0 USB Device",
+    },
+    {
+        "DeviceID": "\\\\.\\PHYSICALDRIVE0",
+        "Model": "Samsung SSD 970 EVO",
+        "SerialNumber": "S4EVNG0123456",
+        "Size": 500107862016,
+        "MediaType": "Fixed hard disk media",
+        "InterfaceType": "SCSI",
+        "Partitions": 4,
+        "Status": "OK",
+        "Caption": "Samsung SSD 970 EVO",
+    },
+])
+
+MOCK_WINDOWS_SINGLE = json.dumps({
+    "DeviceID": "\\\\.\\PHYSICALDRIVE2",
+    "Model": "SanDisk Ultra USB",
+    "SerialNumber": "SD9876",
+    "Size": 32000000000,
+    "MediaType": "Removable Media",
+    "InterfaceType": "USB",
+    "Partitions": 1,
+    "Status": "OK",
+    "Caption": "SanDisk Ultra USB",
+})
+
+MOCK_MACOS_LIST_PLIST = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>WholeDisks</key>
+    <array>
+        <string>disk2</string>
+    </array>
+</dict>
+</plist>"""
+
+MOCK_MACOS_INFO_PLIST = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>DeviceNode</key>
+    <string>/dev/disk2</string>
+    <key>Removable</key>
+    <false/>
+    <key>RemovableMedia</key>
+    <true/>
+    <key>External</key>
+    <true/>
+    <key>Internal</key>
+    <false/>
+    <key>SystemImage</key>
+    <false/>
+    <key>TotalSize</key>
+    <integer>15728640000</integer>
+    <key>MediaName</key>
+    <string>Kingston DataTraveler 3.0</string>
+    <key>VolumeName</key>
+    <string>BOOTFORGE</string>
+    <key>FilesystemType</key>
+    <string>msdos</string>
+    <key>BusProtocol</key>
+    <string>USB</string>
+    <key>IORegistryEntryName</key>
+    <string>Kingston DataTraveler 3.0 Media</string>
+</dict>
+</plist>"""
+
+MOCK_MACOS_SYSTEM_PLIST = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>DeviceNode</key>
+    <string>/dev/disk0</string>
+    <key>Removable</key>
+    <false/>
+    <key>RemovableMedia</key>
+    <false/>
+    <key>External</key>
+    <false/>
+    <key>Internal</key>
+    <true/>
+    <key>SystemImage</key>
+    <true/>
+    <key>TotalSize</key>
+    <integer>500107862016</integer>
+    <key>MediaName</key>
+    <string>APPLE SSD</string>
+</dict>
+</plist>"""
+
+MOCK_UDEVADM_OUTPUT = """DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/host0/target0:0:0/0:0:0:0/block/sdb
+DEVNAME=/dev/sdb
+DEVTYPE=disk
+ID_SERIAL=Kingston_DataTraveler_3.0_KT123456789
+ID_SERIAL_SHORT=KT123456789
+ID_VENDOR=Kingston
+ID_MODEL=DataTraveler_3.0
+ID_BUS=usb
+"""
+
+
+class TestBuildDeviceRecord(unittest.TestCase):
+    def test_removable_usb_eligible(self):
+        rec = _build_device_record(
+            drive_path="/dev/sdb",
+            display_name="Kingston USB",
+            stable_id="linux_sdb_KT123",
+            serial="KT123",
+            size_bytes=15728640000,
+            is_removable=True,
+            is_external=True,
+            is_fixed=False,
+            is_system=False,
+        )
+        self.assertTrue(rec["is_eligible"])
+        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(len(rec["block_reasons"]), 0)
+
+    def test_fixed_internal_blocked(self):
+        rec = _build_device_record(
+            drive_path="/dev/sda",
+            display_name="Samsung SSD",
+            stable_id="linux_sda_S4EVN",
+            serial="S4EVN",
+            size_bytes=500107862016,
+            is_removable=False,
+            is_external=False,
+            is_fixed=True,
+            is_system=False,
+        )
+        self.assertFalse(rec["is_eligible"])
+        self.assertTrue(any("fixed" in r.lower() for r in rec["block_reasons"]))
+
+    def test_system_drive_blocked(self):
+        rec = _build_device_record(
+            drive_path="C:\\",
+            display_name="System SSD",
+            stable_id="win_0_SYS123",
+            serial="SYS123",
+            size_bytes=500107862016,
+            is_removable=False,
+            is_fixed=True,
+            is_system=True,
+        )
+        self.assertFalse(rec["is_eligible"])
+        self.assertTrue(any("system" in r.lower() for r in rec["block_reasons"]))
+
+    def test_missing_serial_lowers_confidence(self):
+        rec = _build_device_record(
+            drive_path="/dev/sdb",
+            display_name="No-serial USB",
+            stable_id=None,
+            serial=None,
+            size_bytes=15728640000,
+            is_removable=True,
+            is_external=True,
+            is_fixed=False,
+            is_system=False,
+        )
+        self.assertEqual(rec["confidence"], "low")
+        self.assertTrue(any("serial" in w.lower() for w in rec["warnings"]))
+
+    def test_stable_id_only_medium_confidence(self):
+        rec = _build_device_record(
+            drive_path="/dev/sdb",
+            display_name="USB Drive",
+            stable_id="linux_sdb_fallback",
+            serial=None,
+            size_bytes=15728640000,
+            is_removable=True,
+            is_external=True,
+            is_fixed=False,
+            is_system=False,
+        )
+        self.assertEqual(rec["confidence"], "medium")
+
+    def test_zero_size_blocked(self):
+        rec = _build_device_record(
+            drive_path="/dev/sdb",
+            display_name="Empty USB",
+            stable_id="linux_sdb_EMPTY",
+            serial="EMPTY",
+            size_bytes=0,
+            is_removable=True,
+            is_external=True,
+            is_fixed=False,
+            is_system=False,
+        )
+        self.assertFalse(rec["is_eligible"])
+        self.assertTrue(any("zero" in r.lower() for r in rec["block_reasons"]))
+
+    def test_all_normalized_fields_present(self):
+        rec = _build_device_record(
+            drive_path="/dev/sdb",
+            display_name="Test",
+            stable_id="test",
+            serial="S123",
+            size_bytes=1024,
+            is_removable=True,
+            is_external=True,
+            is_fixed=False,
+            is_system=False,
+            filesystem="fat32",
+            volume_label="BOOT",
+            bus_protocol="USB",
+            platform="linux",
+            detection_source="test",
+        )
+        for field in [
+            "drive_path", "display_name", "stable_id", "serial",
+            "size_bytes", "size_gb", "size_human", "filesystem",
+            "volume_label", "is_removable", "is_external", "is_fixed",
+            "is_system", "bus_protocol", "platform", "detection_source",
+            "confidence", "is_eligible", "warnings", "block_reasons",
+        ]:
+            self.assertIn(field, rec, f"Missing field: {field}")
+
+
+class TestWindowsScanner(unittest.TestCase):
+    def test_parse_multiple_disks(self):
+        devices = parse_windows_scan_output(MOCK_WINDOWS_PS_OUTPUT)
+        self.assertEqual(len(devices), 2)
+
+        usb = next(d for d in devices if "Kingston" in d["display_name"])
+        self.assertTrue(usb["is_removable"])
+        self.assertTrue(usb["is_eligible"])
+        self.assertEqual(usb["serial"], "KT123456789")
+        self.assertEqual(usb["bus_protocol"], "USB")
+        self.assertEqual(usb["detection_source"], "powershell_win32_diskdrive")
+
+        ssd = next(d for d in devices if "Samsung" in d["display_name"])
+        self.assertFalse(ssd["is_removable"])
+        self.assertTrue(ssd["is_fixed"])
+        self.assertFalse(ssd["is_eligible"])
+
+    def test_parse_single_disk(self):
+        devices = parse_windows_scan_output(MOCK_WINDOWS_SINGLE)
+        self.assertEqual(len(devices), 1)
+        self.assertTrue(devices[0]["is_removable"])
+
+    def test_parse_empty_output(self):
+        self.assertEqual(parse_windows_scan_output(""), [])
+        self.assertEqual(parse_windows_scan_output(None), [])
+        self.assertEqual(parse_windows_scan_output("not json"), [])
+
+    def test_stable_id_includes_serial(self):
+        devices = parse_windows_scan_output(MOCK_WINDOWS_SINGLE)
+        self.assertIn("SD9876", devices[0]["stable_id"])
+
+
+class TestMacOSScanner(unittest.TestCase):
+    def test_parse_disk_list(self):
+        disk_ids = parse_macos_disk_list(MOCK_MACOS_LIST_PLIST)
+        self.assertEqual(disk_ids, ["disk2"])
+
+    def test_parse_disk_info(self):
+        info = parse_macos_disk_info(MOCK_MACOS_INFO_PLIST)
+        self.assertEqual(info["DeviceNode"], "/dev/disk2")
+        self.assertTrue(info["RemovableMedia"])
+        self.assertTrue(info["External"])
+
+    def test_build_removable_device(self):
+        info = parse_macos_disk_info(MOCK_MACOS_INFO_PLIST)
+        device = build_macos_device_from_info("disk2", info)
+        self.assertTrue(device["is_removable"])
+        self.assertTrue(device["is_external"])
+        self.assertFalse(device["is_system"])
+        self.assertTrue(device["is_eligible"])
+        self.assertEqual(device["filesystem"], "msdos")
+        self.assertEqual(device["volume_label"], "BOOTFORGE")
+        self.assertEqual(device["bus_protocol"], "USB")
+        self.assertEqual(device["detection_source"], "diskutil_plist")
+
+    def test_build_system_device_blocked(self):
+        info = parse_macos_disk_info(MOCK_MACOS_SYSTEM_PLIST)
+        device = build_macos_device_from_info("disk0", info)
+        self.assertFalse(device["is_eligible"])
+        self.assertTrue(device["is_system"])
+        self.assertTrue(any("system" in r.lower() for r in device["block_reasons"]))
+
+    def test_parse_invalid_plist(self):
+        self.assertEqual(parse_macos_disk_list(b"not a plist"), [])
+        self.assertEqual(parse_macos_disk_info(b"not a plist"), {})
+
+
+class TestLinuxScanner(unittest.TestCase):
+    def test_parse_udevadm_output(self):
+        props = parse_udevadm_output(MOCK_UDEVADM_OUTPUT)
+        self.assertEqual(props["ID_SERIAL_SHORT"], "KT123456789")
+        self.assertEqual(props["ID_VENDOR"], "Kingston")
+        self.assertEqual(props["ID_BUS"], "usb")
+
+    def test_parse_empty_udevadm(self):
+        self.assertEqual(parse_udevadm_output(""), {})
+        self.assertEqual(parse_udevadm_output(None), {})
+
+    def test_read_sysfs_nonexistent(self):
+        self.assertIsNone(read_sysfs_file("/sys/block/definitely_not_a_device/removable"))
+
+
+class TestScanDevicesAPI(unittest.TestCase):
+    @patch("device_scanner.scan_windows")
+    def test_scan_windows_platform(self, mock_scan):
+        mock_scan.return_value = (
+            [_build_device_record(
+                drive_path="\\\\.\\PHYSICALDRIVE1",
+                display_name="USB Drive",
+                stable_id="win_1_SN",
+                serial="SN",
+                size_bytes=16000000000,
+                is_removable=True,
+                is_external=True,
+                is_fixed=False,
+                is_system=False,
+                platform="win32",
+                detection_source="powershell_win32_diskdrive",
+            )],
+            [],
+        )
+        result = scan_devices(platform_override="win32")
+        self.assertEqual(result["schema"], SCANNER_SCHEMA)
+        self.assertEqual(result["platform"], "win32")
+        self.assertEqual(result["device_count"], 1)
+        self.assertTrue(result["safe_mode"])
+        self.assertFalse(result["destructive"])
+
+    @patch("device_scanner.scan_macos")
+    def test_scan_macos_platform(self, mock_scan):
+        mock_scan.return_value = ([], [])
+        result = scan_devices(platform_override="darwin")
+        self.assertEqual(result["platform"], "darwin")
+        self.assertEqual(result["detection_source"], "diskutil_plist")
+
+    @patch("device_scanner.scan_linux")
+    def test_scan_linux_platform(self, mock_scan):
+        mock_scan.return_value = ([], [])
+        result = scan_devices(platform_override="linux")
+        self.assertEqual(result["platform"], "linux")
+
+    def test_unsupported_platform(self):
+        result = scan_devices(platform_override="freebsd")
+        self.assertEqual(result["device_count"], 0)
+        self.assertTrue(any("Unsupported" in w for w in result["scan_warnings"]))
+
+    def test_result_json_serializable(self):
+        result = scan_devices(platform_override="freebsd")
+        serialized = json.dumps(result)
+        self.assertIsInstance(serialized, str)
+
+    def test_scan_id_present(self):
+        result = scan_devices(platform_override="freebsd")
+        self.assertTrue(result["scan_id"].startswith("scan_"))
+        self.assertIsNotNone(result["created_at"])
+
+
+class TestGetDeviceByPath(unittest.TestCase):
+    def test_find_existing_device(self):
+        scan = {"devices": [
+            {"drive_path": "/dev/sda", "display_name": "SSD"},
+            {"drive_path": "/dev/sdb", "display_name": "USB"},
+        ]}
+        device = get_device_by_path(scan, "/dev/sdb")
+        self.assertEqual(device["display_name"], "USB")
+
+    def test_missing_device_returns_none(self):
+        scan = {"devices": [{"drive_path": "/dev/sda"}]}
+        self.assertIsNone(get_device_by_path(scan, "/dev/sdc"))
+
+
+class TestGetEligibleDevices(unittest.TestCase):
+    def test_filters_eligible_only(self):
+        scan = {"devices": [
+            {"drive_path": "/dev/sda", "is_eligible": False},
+            {"drive_path": "/dev/sdb", "is_eligible": True},
+            {"drive_path": "/dev/sdc", "is_eligible": True},
+        ]}
+        eligible = get_eligible_devices(scan)
+        self.assertEqual(len(eligible), 2)
+
+
+class TestAmbiguousTarget(unittest.TestCase):
+    def test_plain_path_not_in_scan_returns_none(self):
+        scan = {"devices": [
+            {"drive_path": "/dev/sdb", "is_eligible": True},
+        ]}
+        self.assertIsNone(get_device_by_path(scan, "E:\\"))
+        self.assertIsNone(get_device_by_path(scan, "/dev/disk2"))
+
+
+class TestNoDestructiveCallSites(unittest.TestCase):
+    def test_scanner_source_has_no_destructive_calls(self):
+        scanner_path = Path(__file__).parent.parent / "device_scanner.py"
+        with open(scanner_path, "r", encoding="utf-8") as f:
+            content = f.read().lower()
+        self.assertNotIn("diskpart", content)
+        self.assertNotIn("mkfs", content)
+        self.assertNotIn("unmount", content)
+        self.assertNotIn("createfile", content)
+        self.assertNotIn("writefile", content)
+        self.assertNotIn("deviceiocontrol", content)
+
+
+class TestDashboardNoForbiddenLabels(unittest.TestCase):
+    def test_dashboard_has_no_forbidden_labels(self):
+        dashboard_path = Path(__file__).parent.parent / "dashboard" / "src" / "App.jsx"
+        if not dashboard_path.exists():
+            self.skipTest("Dashboard source not found")
+        with open(dashboard_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        forbidden = [
+            "Write USB", "Burn USB", "Flash USB", "Start Write",
+            "Format USB", "Erase Drive", "Arm Writer", "Execute Write",
+            "Destructive Write", "Write Now",
+        ]
+        for label in forbidden:
+            self.assertNotIn(label, content, f"Forbidden label found: {label}")
+
+
+class TestCommandFailureSafety(unittest.TestCase):
+    @patch("device_scanner.scan_windows")
+    def test_windows_failure_returns_safe_result(self, mock_scan):
+        mock_scan.return_value = ([], ["PowerShell scan failed (code 1): error"])
+        result = scan_devices(platform_override="win32")
+        self.assertEqual(result["device_count"], 0)
+        self.assertTrue(len(result["scan_warnings"]) > 0)
+        self.assertEqual(result["schema"], SCANNER_SCHEMA)
+
+    @patch("device_scanner.scan_macos")
+    def test_macos_failure_returns_safe_result(self, mock_scan):
+        mock_scan.return_value = ([], ["diskutil failed"])
+        result = scan_devices(platform_override="darwin")
+        self.assertEqual(result["device_count"], 0)
+        self.assertTrue(len(result["scan_warnings"]) > 0)
+
+    @patch("device_scanner.scan_linux")
+    def test_linux_failure_returns_safe_result(self, mock_scan):
+        mock_scan.return_value = ([], ["sysblock read failed"])
+        result = scan_devices(platform_override="linux")
+        self.assertEqual(result["device_count"], 0)
+
+
+class TestHumanSize(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(_human_size(0), "0 B")
+
+    def test_bytes(self):
+        self.assertEqual(_human_size(500), "500.0 B")
+
+    def test_gigabytes(self):
+        result = _human_size(15728640000)
+        self.assertIn("GB", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds Phase 5B-1: Cross-Platform Device Scanner Consolidation.

The milestone extracts useful read-only device detection patterns from prior BootForge prototype sources and consolidates them into PhoenixCore as a normalized cross-platform scanner module.

## What Changed

Added:

- `device_scanner.py`
- `tests/test_device_scanner.py`
- `docs/evidence/phase5b1-cross-platform-device-scanner-consolidation.md`

## Scanner Scope

This is a read-only scanner upgrade only.

This PR does **not** add:

- physical USB writing
- formatting
- partition editing
- mount automation
- unmount automation
- dashboard write trigger
- consumer write mode
- raw physical device write access

## Platform Detection

Adds normalized device scanning support for:

- Windows via PowerShell `Get-CimInstance Win32_DiskDrive` parsing
- macOS via `diskutil list/info -plist` parsing
- Linux via `/sys/block`, `udevadm` serial fallback, and `lsblk` fallback

## Schema

Adds normalized schema:

```text
bootforge.device_scan.v2
```

Normalized device fields include:

- drive path
- display name
- stable ID
- serial when available
- size bytes
- filesystem when available
- volume label when available
- removable/external/fixed/system flags
- bus/protocol when available
- platform
- detection source
- confidence
- warnings
- block reasons

## Safety Behavior

The scanner is defensive by default:

- Missing serial or stable ID lowers confidence.
- Fixed/internal/system targets are marked unsafe.
- Platform command failures return safe degraded results instead of crashing.
- Ambiguous targets block instead of auto-selecting.
- Plain paths are not treated as safe without scan evidence.

## Source Mining

Reviewed source patterns from:

- `device_scanner.py`
- `bootforge.py`

Rejected copying whole prototype files. Extracted only detection patterns and normalized them into PhoenixCore-style safe output.

## Tests

Added:

```text
tests/test_device_scanner.py
```

Claude Code verification:

```text
37/37 tests passed
```

## Dashboard Build

Claude Code reported:

```text
Dashboard builds cleanly
```

## Danger Scan Summary

Claude Code reported:

```text
Danger scan: clean
UI label scan: clean
No physical writing added
```

## Evidence

Evidence document:

```text
docs/evidence/phase5b1-cross-platform-device-scanner-consolidation.md
```

## Review Notes

Review should confirm:

- scanner remains read-only
- no destructive command call sites were introduced
- dashboard has no write trigger
- normalized output is compatible with future PhoenixCore preflight/safety flows
- fixed/internal/system targets are blocked
- command failures degrade safely
- no prototype noise was imported wholesale