### PR TITLE
Add gated Windows physical USB write lab

### DIFF
--- a/device_scanner.py
+++ b/device_scanner.py
@@ -147,9 +147,15 @@ def _run_command_bytes(cmd, timeout=10):
 # ---------------------------------------------------------------------------
 
 WINDOWS_PS_SCRIPT = (
-    "Get-CimInstance Win32_DiskDrive | "
-    "Select-Object DeviceID, Model, SerialNumber, Size, MediaType, "
-    "InterfaceType, Partitions, Status, Caption | ConvertTo-Json"
+    "Get-CimInstance Win32_DiskDrive | ForEach-Object { "
+    "$disk = $_; "
+    "$number = [int](($disk.DeviceID -replace '[^0-9]', '')); "
+    "$storage = Get-Disk -Number $number -ErrorAction SilentlyContinue; "
+    "[PSCustomObject]@{ DeviceID=$disk.DeviceID; Model=$disk.Model; "
+    "SerialNumber=$disk.SerialNumber; Size=$disk.Size; MediaType=$disk.MediaType; "
+    "InterfaceType=$disk.InterfaceType; Partitions=$disk.Partitions; "
+    "Status=$disk.Status; Caption=$disk.Caption; IsBoot=[bool]$storage.IsBoot; "
+    "IsSystem=[bool]$storage.IsSystem } } | ConvertTo-Json"
 )
 
 
@@ -173,6 +179,7 @@ def parse_windows_scan_output(raw_json):
         model = (item.get("Model") or "").strip() or None
         interface = (item.get("InterfaceType") or "").strip()
         media_type = (item.get("MediaType") or "").strip().lower()
+        is_system = bool(item.get("IsBoot") or item.get("IsSystem"))
 
         is_removable = (
             interface in ("USB", "SD", "1394")
@@ -198,7 +205,7 @@ def parse_windows_scan_output(raw_json):
                 is_removable=is_removable,
                 is_external=is_removable,
                 is_fixed=is_fixed,
-                is_system=False,
+                is_system=is_system,
                 bus_protocol=interface or None,
                 platform="win32",
                 detection_source="powershell_win32_diskdrive",

--- a/docs/evidence/windows-physical-usb-write-lab.md
+++ b/docs/evidence/windows-physical-usb-write-lab.md
@@ -1,0 +1,89 @@
+# Windows Physical USB Write Lab
+
+This lane enables one CLI-only, byte-for-byte image write to a scanner-proven
+external Windows disk. It does not add a Phoenix Key dashboard write button and
+does not enable macOS, Linux, fixed-disk, internal-disk, or system-disk writes.
+
+## Required safety chain
+
+The writer opens a raw disk only when all of these conditions are true:
+
+- Windows process is elevated.
+- `BOOTFORGE_ENABLE_PHYSICAL_USB_WRITE` has the exact lab unlock value.
+- Target is an exact `\\.\PHYSICALDRIVE<n>` path.
+- Live scanner says the target is removable/external, not fixed, and not system.
+- Fresh scanner identity matches the saved identity lock.
+- Identity lock, preflight, and dry-run receipts all name the same target.
+- Preflight and dry-run image hashes match the current image SHA-256.
+- Dry-run receipt is eligible, unblocked, non-destructive, and wrote zero bytes.
+- Image fits on the target.
+- Explicit byte cap exactly equals the image size.
+- All three risk phrases and the exact raw target are re-entered.
+- A pre-write ledger record is flushed to disk before the raw handle opens.
+- Windows grants an exclusive raw-disk handle. Mounted or busy targets fail closed.
+
+## Controlled Windows procedure
+
+Run PowerShell **as Administrator** from the repository root. Use only a
+sacrificial external disk. The commands below assume the intended target was
+independently confirmed as `PHYSICALDRIVE1` in Disk Management.
+
+```powershell
+$Target = '\\.\PHYSICALDRIVE1'
+$Image = 'C:\Users\Bobby\Downloads\iCloudDrive\home-native.iso'
+$Evidence = Join-Path $PWD 'physical-write-evidence'
+New-Item -ItemType Directory -Path $Evidence -ErrorAction Stop
+
+$env:BOOTFORGE_ENABLE_PHYSICAL_USB_WRITE = 'I_ACCEPT_SACRIFICIAL_USB_WRITE_RISK'
+$ImageBytes = (Get-Item -LiteralPath $Image).Length
+
+python .\usb_creator.py --lock-removable-target `
+  --target-drive $Target `
+  --export-identity-lock-json (Join-Path $Evidence 'identity-lock.json')
+
+python .\usb_creator.py --hardware-writer-preflight `
+  --target-drive $Target --image $Image `
+  --export-hardware-preflight-json (Join-Path $Evidence 'preflight.json')
+
+python .\usb_creator.py --plan-write `
+  --target-drive $Target --image $Image `
+  --export-write-plan-json (Join-Path $Evidence 'write-plan.json')
+
+python .\usb_creator.py --audit-plan `
+  --target-drive $Target --image $Image `
+  --export-json (Join-Path $Evidence 'audit.json')
+
+python .\usb_creator.py --simulate-write `
+  --target-drive $Target --image $Image `
+  --export-mock-write-json (Join-Path $Evidence 'simulation.json')
+```
+
+Inspect all three JSON files before continuing. The write plan must show
+`eligible: true`, `blocked: false`, `actual_write_enabled: false`, and the exact
+target and image hash.
+
+Close every Explorer window or program using the external disk. If Windows still
+mounts it, take only the confirmed sacrificial target disk offline in Disk
+Management. Do not take the internal/system disk offline.
+
+Then run the final command:
+
+```powershell
+python .\usb_creator.py --physical-usb-write-lab `
+  --target-drive $Target --confirm-physical-target $Target `
+  --image $Image --physical-write-max-bytes $ImageBytes `
+  --physical-write-chunk-size 1048576 --verify-after-write `
+  --require-identity-lock (Join-Path $Evidence 'identity-lock.json') `
+  --require-preflight-result (Join-Path $Evidence 'preflight.json') `
+  --require-dryrun-result (Join-Path $Evidence 'write-plan.json') `
+  --require-audit-result (Join-Path $Evidence 'audit.json') `
+  --require-simulation-result (Join-Path $Evidence 'simulation.json') `
+  --append-writer-contract-ledger (Join-Path $Evidence 'write-ledger.jsonl') `
+  --export-physical-write-json (Join-Path $Evidence 'write-result.json') `
+  --typed-confirmation 'I UNDERSTAND THIS WILL OVERWRITE THE SELECTED PHYSICAL USB DRIVE' `
+  --destructive-acknowledgement 'I CONFIRM THIS IS A SACRIFICIAL REMOVABLE TEST USB DRIVE' `
+  --final-irreversible-acknowledgement 'I ACCEPT FULL RESPONSIBILITY FOR THIS TEST USB WRITE'
+```
+
+Success requires the full image byte count and a matching read-back SHA-256.
+Any mismatch or Windows raw-handle error returns a blocked result and stops.

--- a/real_writer_interface.py
+++ b/real_writer_interface.py
@@ -7,6 +7,7 @@ Defines standard request, result, and adapter interface models for lab-only raw 
 """
 
 import os
+import re
 import sys
 import uuid
 import hashlib
@@ -1383,6 +1384,7 @@ PHYSICAL_DESTRUCTIVE_ACKNOWLEDGEMENT = (
     "I CONFIRM THIS IS A SACRIFICIAL REMOVABLE TEST USB DRIVE"
 )
 PHYSICAL_FINAL_IRREVERSIBLE = "I ACCEPT FULL RESPONSIBILITY FOR THIS TEST USB WRITE"
+WINDOWS_RAW_DEVICE_RE = re.compile(r"^\\\\\.\\PHYSICALDRIVE([0-9]+)$", re.IGNORECASE)
 
 
 def build_physical_usb_write_lab_request(**kwargs) -> dict:
@@ -1430,6 +1432,20 @@ def build_physical_usb_write_lab_request(**kwargs) -> dict:
         "verify_after_write": kwargs.get("verify_after_write", False),
         "physical_write_requested": kwargs.get("physical_write_requested", False),
         "physical_write_allowed": kwargs.get("physical_write_allowed", False),
+        "target_confirmation": kwargs.get("target_confirmation"),
+        "target_is_removable": kwargs.get("target_is_removable", False),
+        "target_is_external": kwargs.get("target_is_external", False),
+        "target_is_fixed": kwargs.get("target_is_fixed", True),
+        "target_is_system_drive": kwargs.get("target_is_system_drive", True),
+        "target_size_bytes": kwargs.get("target_size_bytes", 0),
+        "scanner_confidence": kwargs.get("scanner_confidence"),
+        "fresh_rescan_match": kwargs.get("fresh_rescan_match", False),
+        "dryrun_wrote_zero_bytes": kwargs.get("dryrun_wrote_zero_bytes", False),
+        "evidence_target_matches": kwargs.get("evidence_target_matches", False),
+        "evidence_image_matches": kwargs.get("evidence_image_matches", False),
+        "audit_passed": kwargs.get("audit_passed", False),
+        "simulation_passed": kwargs.get("simulation_passed", False),
+        "physical_write_max_bytes": kwargs.get("physical_write_max_bytes"),
     }
 
 
@@ -1523,10 +1539,43 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
 
     if not request.get("target_drive"):
         block_reasons.append("Target drive is missing.")
+    elif not WINDOWS_RAW_DEVICE_RE.fullmatch(str(request.get("target_drive"))):
+        block_reasons.append(
+            "Target must be an exact Windows raw disk path such as \\\\.\\PHYSICALDRIVE1."
+        )
     if not request.get("target_stable_id"):
         block_reasons.append("Target stable ID is missing.")
     if not request.get("target_identity_hash"):
         block_reasons.append("Target identity hash is missing.")
+
+    if request.get("target_confirmation") != request.get("target_drive"):
+        block_reasons.append("Exact target-drive confirmation mismatch.")
+    if not (request.get("target_is_removable") or request.get("target_is_external")):
+        block_reasons.append("Target is not proven removable/external by the scanner.")
+    if request.get("target_is_fixed"):
+        block_reasons.append("Target is fixed/internal and cannot be written.")
+    if request.get("target_is_system_drive"):
+        block_reasons.append("Target is a system/boot drive and cannot be written.")
+    if not request.get("target_size_bytes") or request.get("target_size_bytes", 0) <= 0:
+        block_reasons.append("Target capacity is missing or invalid.")
+    if request.get("scanner_confidence") not in ("high", "medium"):
+        block_reasons.append("Scanner confidence is too low for physical writing.")
+    if not request.get("fresh_rescan_match"):
+        block_reasons.append("Fresh target re-scan does not match the identity lock.")
+    if not request.get("dryrun_wrote_zero_bytes"):
+        block_reasons.append(
+            "Required dry-run evidence does not prove zero bytes written."
+        )
+    if not request.get("evidence_target_matches"):
+        block_reasons.append("Receipt target does not match the requested raw disk.")
+    if not request.get("evidence_image_matches"):
+        block_reasons.append("Receipt image does not match the current image hash.")
+    if not request.get("audit_passed"):
+        block_reasons.append("Write-plan audit receipt did not pass.")
+    if not request.get("simulation_passed"):
+        block_reasons.append("Mock-writer simulation receipt did not pass.")
+    if not request.get("verify_after_write"):
+        block_reasons.append("Post-write read-back SHA256 verification is required.")
 
     if not request.get("identity_lock_id"):
         block_reasons.append("Identity lock ID is missing.")
@@ -1544,6 +1593,15 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
         block_reasons.append("Image SHA256 is missing.")
     if not request.get("image_size_bytes") or request["image_size_bytes"] <= 0:
         block_reasons.append("Image size is missing or zero.")
+    elif request.get("target_size_bytes", 0) < request.get("image_size_bytes", 0):
+        block_reasons.append("Verified image is larger than the selected target disk.")
+    max_bytes = request.get("physical_write_max_bytes")
+    if max_bytes is None:
+        block_reasons.append("Explicit physical write byte cap is missing.")
+    elif max_bytes != request.get("image_size_bytes"):
+        block_reasons.append(
+            "Physical write byte cap must exactly equal the verified image size."
+        )
 
     if not request.get("preflight_id"):
         block_reasons.append("Hardware preflight ID is missing.")
@@ -1557,6 +1615,8 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
     if not request.get("ledger_path"):
         block_reasons.append("Ledger path is missing.")
     else:
+        from pathlib import Path
+
         ledger_path = request["ledger_path"]
         lp_str = str(ledger_path).strip().lower()
         for suspicious in [
@@ -1571,6 +1631,9 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
         ]:
             if suspicious in lp_str.replace("\\", "/"):
                 block_reasons.append(f"Ledger path in {suspicious} folders is blocked.")
+        ledger_parent = Path(ledger_path).resolve().parent
+        if not ledger_parent.exists() or not ledger_parent.is_dir():
+            block_reasons.append("Ledger parent directory does not exist.")
 
     tc = request.get("typed_confirmation") or ""
     if tc.strip() != PHYSICAL_TYPED_CONFIRMATION:
@@ -1586,6 +1649,8 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
 
     if not request.get("physical_write_requested"):
         block_reasons.append("Physical write was not explicitly requested.")
+    if not request.get("sacrificial_drive_confirmed"):
+        block_reasons.append("Sacrificial-drive confirmation is missing.")
     if not request.get("lab_mode"):
         block_reasons.append("Lab mode is not enabled.")
 
@@ -1597,6 +1662,268 @@ def validate_physical_usb_write_lab_gates(request: dict) -> tuple:
 
     is_valid = len(block_reasons) == 0
     return is_valid, block_reasons
+
+
+def _hash_file(path: str, byte_limit: int = None) -> str:
+    digest = hashlib.sha256()
+    remaining = byte_limit
+    with open(path, "rb") as stream:
+        while remaining is None or remaining > 0:
+            read_size = 1024 * 1024
+            if remaining is not None:
+                read_size = min(read_size, remaining)
+            chunk = stream.read(read_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+            if remaining is not None:
+                remaining -= len(chunk)
+    return digest.hexdigest()
+
+
+class RawWriteError(OSError):
+    def __init__(self, message: str, bytes_written: int):
+        super().__init__(message)
+        self.bytes_written = bytes_written
+
+
+def _write_image_to_seekable_target(image_path: str, target, chunk_size: int) -> int:
+    """Byte-copy engine kept separate so it can be tested without raw hardware."""
+    bytes_written = 0
+    target.seek(0)
+    with open(image_path, "rb") as source:
+        while True:
+            chunk = source.read(chunk_size)
+            if not chunk:
+                break
+            try:
+                written = target.write(chunk)
+            except Exception as exc:
+                raise RawWriteError(
+                    f"Raw-device write failed after {bytes_written} bytes: {exc}",
+                    bytes_written,
+                ) from exc
+            if written != len(chunk):
+                partial_total = bytes_written + max(int(written or 0), 0)
+                raise RawWriteError(
+                    f"Short raw-device write: expected {len(chunk)} bytes, wrote {written}.",
+                    partial_total,
+                )
+            bytes_written += written
+    target.flush()
+    try:
+        os.fsync(target.fileno())
+    except (AttributeError, OSError):
+        pass
+    return bytes_written
+
+
+def _open_windows_raw_device_exclusive(target_path: str):
+    """Return an unbuffered file object backed by an exclusive Win32 disk handle."""
+    if sys.platform != "win32":
+        raise OSError("Windows raw-device handles are only available on win32.")
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+
+    generic_read = 0x80000000
+    generic_write = 0x40000000
+    open_existing = 3
+    file_attribute_normal = 0x80
+    file_flag_write_through = 0x80000000
+    invalid_handle_value = wintypes.HANDLE(-1).value
+
+    handle = create_file(
+        target_path,
+        generic_read | generic_write,
+        0,  # no sharing: any mounted/in-use target fails closed
+        None,
+        open_existing,
+        file_attribute_normal | file_flag_write_through,
+        None,
+    )
+    if handle == invalid_handle_value:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    try:
+        fd = msvcrt.open_osfhandle(handle, os.O_RDWR | os.O_BINARY)
+    except Exception:
+        kernel32.CloseHandle(handle)
+        raise
+    return os.fdopen(fd, "r+b", buffering=0)
+
+
+def _execute_windows_physical_usb_write(request: dict, adapter_name: str) -> dict:
+    """Perform one fully gated, CLI-only Windows raw-disk image write."""
+    started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    target_path = request.get("target_drive")
+    image_path = request.get("image_path")
+    expected_hash = request.get("image_sha256")
+    image_size = request.get("image_size_bytes") or 0
+    chunk_size = request.get("chunk_size_bytes") or 1024 * 1024
+
+    if not image_path or not os.path.isfile(image_path):
+        return build_physical_usb_write_lab_result(
+            request_id=request.get("request_id"),
+            adapter=adapter_name,
+            lab_mode=True,
+            target_drive=target_path,
+            blocked=True,
+            block_reasons=["Source image file disappeared before physical write."],
+            next_required_action="restore_and_reverify_source_image",
+        )
+
+    actual_size = os.path.getsize(image_path)
+    actual_hash = _hash_file(image_path)
+    if actual_size != image_size or actual_hash != expected_hash:
+        return build_physical_usb_write_lab_result(
+            request_id=request.get("request_id"),
+            adapter=adapter_name,
+            lab_mode=True,
+            target_drive=target_path,
+            image_path=image_path,
+            image_sha256_expected=expected_hash,
+            image_size_bytes=image_size,
+            blocked=True,
+            block_reasons=[
+                "Source image changed after the safety evidence was created."
+            ],
+            next_required_action="regenerate_all_write_evidence",
+        )
+
+    bytes_written = 0
+    chunks_written = 0
+    verification_hash = None
+    try:
+        # Exclusive open is deliberate: if Windows or another program is using any
+        # target volume, this fails closed instead of forcing a dismount behind the
+        # operator's back.
+        with _open_windows_raw_device_exclusive(target_path) as raw_target:
+            bytes_written = _write_image_to_seekable_target(
+                image_path, raw_target, chunk_size
+            )
+            chunks_written = (bytes_written + chunk_size - 1) // chunk_size
+            raw_target.seek(0)
+            digest = hashlib.sha256()
+            remaining = image_size
+            while remaining > 0:
+                chunk = raw_target.read(min(chunk_size, remaining))
+                if not chunk:
+                    raise OSError("Raw-device verification ended before image size.")
+                digest.update(chunk)
+                remaining -= len(chunk)
+            verification_hash = digest.hexdigest()
+
+        verification_passed = (
+            bytes_written == image_size and verification_hash == expected_hash
+        )
+        completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return build_physical_usb_write_lab_result(
+            request_id=request.get("request_id"),
+            adapter=adapter_name,
+            lab_mode=True,
+            physical_write_allowed=True,
+            physical_write_attempted=True,
+            physical_write_started_at=started_at,
+            physical_write_completed_at=completed_at,
+            target_drive=target_path,
+            target_stable_id=request.get("target_stable_id"),
+            target_identity_hash=request.get("target_identity_hash"),
+            latest_identity_hash=request.get("latest_identity_hash"),
+            image_path=image_path,
+            image_sha256_expected=expected_hash,
+            image_size_bytes=image_size,
+            chunk_size_bytes=chunk_size,
+            chunks_expected=request.get("expected_chunk_count", 0),
+            chunks_written=chunks_written,
+            bytes_expected=image_size,
+            bytes_written=bytes_written,
+            verification_requested=True,
+            verification_sha256=verification_hash,
+            verification_passed=verification_passed,
+            blocked=not verification_passed,
+            block_reasons=(
+                []
+                if verification_passed
+                else ["Post-write SHA256 verification failed."]
+            ),
+            warnings=[
+                "The selected physical disk was overwritten from byte zero. Partition metadata previously on that disk is no longer authoritative."
+            ],
+            next_required_action=(
+                "safely_eject_and_boot_test"
+                if verification_passed
+                else "stop_and_preserve_write_evidence"
+            ),
+        )
+    except Exception as exc:
+        if isinstance(exc, RawWriteError):
+            bytes_written = exc.bytes_written
+            chunks_written = (bytes_written + chunk_size - 1) // chunk_size
+        completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return build_physical_usb_write_lab_result(
+            request_id=request.get("request_id"),
+            adapter=adapter_name,
+            lab_mode=True,
+            physical_write_allowed=True,
+            physical_write_attempted=bytes_written > 0,
+            physical_write_started_at=started_at,
+            physical_write_completed_at=completed_at,
+            target_drive=target_path,
+            target_stable_id=request.get("target_stable_id"),
+            target_identity_hash=request.get("target_identity_hash"),
+            latest_identity_hash=request.get("latest_identity_hash"),
+            image_path=image_path,
+            image_sha256_expected=expected_hash,
+            image_size_bytes=image_size,
+            chunk_size_bytes=chunk_size,
+            chunks_expected=request.get("expected_chunk_count", 0),
+            chunks_written=chunks_written,
+            bytes_expected=image_size,
+            bytes_written=bytes_written,
+            verification_requested=True,
+            verification_sha256=verification_hash,
+            verification_passed=False,
+            blocked=True,
+            block_reasons=[f"Windows raw-device write failed closed: {exc}"],
+            next_required_action="close_target_volume_users_and_recreate_evidence",
+        )
+
+
+def _append_physical_write_ledger(path: str, event: str, payload: dict) -> None:
+    import json
+
+    record = {
+        "schema": "bootforge.physical_usb_write_ledger.v1",
+        "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "event": event,
+        "request_id": payload.get("request_id"),
+        "target_drive": payload.get("target_drive"),
+        "target_identity_hash": payload.get("target_identity_hash"),
+        "image_sha256": payload.get("image_sha256")
+        or payload.get("image_sha256_expected"),
+        "bytes_written": payload.get("bytes_written", 0),
+        "blocked": payload.get("blocked"),
+        "verification_passed": payload.get("verification_passed", False),
+    }
+    with open(path, "a", encoding="utf-8") as ledger:
+        ledger.write(json.dumps(record, sort_keys=True) + "\n")
+        ledger.flush()
+        os.fsync(ledger.fileno())
 
 
 class PhysicalUSBWriteLabAdapter:
@@ -1625,27 +1952,33 @@ class PhysicalUSBWriteLabAdapter:
                 next_required_action="resolve_physical_write_blockers",
             )
 
-        block_reasons.append("physical_writer_not_safely_implemented")
-        return build_physical_usb_write_lab_result(
-            request_id=request.get("request_id"),
-            adapter=self.name,
-            lab_mode=request.get("lab_mode", False),
-            physical_write_allowed=False,
-            physical_write_attempted=False,
-            target_drive=request.get("target_drive"),
-            target_stable_id=request.get("target_stable_id"),
-            target_identity_hash=request.get("target_identity_hash"),
-            latest_identity_hash=request.get("latest_identity_hash"),
-            image_path=request.get("image_path"),
-            image_sha256_expected=request.get("image_sha256"),
-            image_size_bytes=request.get("image_size_bytes", 0),
-            blocked=True,
-            block_reasons=block_reasons,
-            warnings=[
-                "Physical USB write adapter exists but raw device I/O is not safely implemented yet. All gates passed but write was not attempted."
-            ],
-            next_required_action="implement_safe_physical_writer",
-        )
+        try:
+            _append_physical_write_ledger(
+                request["ledger_path"], "physical_write_armed", request
+            )
+        except Exception as exc:
+            return build_physical_usb_write_lab_result(
+                request_id=request.get("request_id"),
+                adapter=self.name,
+                lab_mode=True,
+                target_drive=request.get("target_drive"),
+                target_stable_id=request.get("target_stable_id"),
+                target_identity_hash=request.get("target_identity_hash"),
+                blocked=True,
+                block_reasons=[f"Could not persist pre-write ledger receipt: {exc}"],
+                next_required_action="repair_ledger_path_before_retry",
+            )
+
+        result = _execute_windows_physical_usb_write(request, adapter_name=self.name)
+        try:
+            _append_physical_write_ledger(
+                request["ledger_path"], "physical_write_finished", result
+            )
+        except Exception as exc:
+            result.setdefault("warnings", []).append(
+                f"Post-write ledger receipt could not be persisted: {exc}"
+            )
+        return result
 
 
 def build_physical_usb_write_lab_status() -> dict:
@@ -1661,7 +1994,8 @@ def build_physical_usb_write_lab_status() -> dict:
     return {
         "schema": "bootforge.physical_usb_write_lab_status.v1",
         "platform": plat,
-        "physical_write_implemented": False,
+        "physical_write_implemented": True,
+        "platform_supported": plat == "win32",
         "physical_write_allowed": False,
         "physical_write_cli_only": True,
         "dashboard_write_blocked": True,
@@ -1699,9 +2033,11 @@ def build_physical_usb_write_lab_status() -> dict:
             "target_path_maps_to_scanned_locked_target",
         ],
         "blocked": True,
-        "block_reasons": ["Physical USB write adapter is not safely implemented yet."],
+        "block_reasons": [
+            "Physical writing is not armed; all CLI evidence and confirmation gates are required."
+        ],
         "warnings": [],
-        "next_required_action": "implement_safe_physical_writer",
+        "next_required_action": "satisfy_cli_physical_write_gates",
     }
 
 

--- a/tests/test_device_scanner.py
+++ b/tests/test_device_scanner.py
@@ -320,6 +320,14 @@ class TestWindowsScanner(unittest.TestCase):
         devices = parse_windows_scan_output(MOCK_WINDOWS_SINGLE)
         self.assertIn("SD9876", devices[0]["stable_id"])
 
+    def test_windows_boot_disk_is_blocked_even_when_usb(self):
+        boot_usb = json.loads(MOCK_WINDOWS_SINGLE)
+        boot_usb["IsBoot"] = True
+        devices = parse_windows_scan_output(json.dumps(boot_usb))
+        self.assertTrue(devices[0]["is_system"])
+        self.assertFalse(devices[0]["is_eligible"])
+        self.assertIn("Drive is a system/boot drive.", devices[0]["block_reasons"])
+
 
 class TestMacOSScanner(unittest.TestCase):
     def test_parse_disk_list(self):

--- a/tests/test_physical_usb_write_lab.py
+++ b/tests/test_physical_usb_write_lab.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import json
+import io
 import tempfile
 import sys
 from pathlib import Path
@@ -24,6 +25,8 @@ from real_writer_interface import (
     export_physical_usb_write_lab_json,
     export_physical_usb_write_lab_markdown,
     generate_physical_usb_write_lab_markdown,
+    _write_image_to_seekable_target,
+    RawWriteError,
 )
 
 
@@ -91,7 +94,7 @@ class TestPhysicalUSBWriteLabGates(unittest.TestCase):
 
         self.valid_request = build_physical_usb_write_lab_request(
             platform="win32",
-            target_drive="E:\\",
+            target_drive=r"\\.\PHYSICALDRIVE1",
             target_stable_id="usb_stable_001",
             target_identity_hash="hash_abc",
             latest_identity_hash="hash_abc",
@@ -113,6 +116,21 @@ class TestPhysicalUSBWriteLabGates(unittest.TestCase):
             running_as_admin_or_root=True,
             physical_write_requested=True,
             physical_write_allowed=False,
+            verify_after_write=True,
+            target_confirmation=r"\\.\PHYSICALDRIVE1",
+            target_is_removable=True,
+            target_is_external=True,
+            target_is_fixed=False,
+            target_is_system_drive=False,
+            target_size_bytes=1000000000,
+            scanner_confidence="high",
+            fresh_rescan_match=True,
+            dryrun_wrote_zero_bytes=True,
+            evidence_target_matches=True,
+            evidence_image_matches=True,
+            audit_passed=True,
+            simulation_passed=True,
+            physical_write_max_bytes=5242880,
         )
 
     def tearDown(self):
@@ -225,6 +243,25 @@ class TestPhysicalUSBWriteLabGates(unittest.TestCase):
         self.assertFalse(is_valid)
         self.assertTrue(any("not implemented" in r.lower() for r in reasons))
 
+    def test_raw_device_path_required(self):
+        self.valid_request["target_drive"] = "E:\\"
+        self.valid_request["target_confirmation"] = "E:\\"
+        is_valid, reasons = validate_physical_usb_write_lab_gates(self.valid_request)
+        self.assertFalse(is_valid)
+        self.assertTrue(any("raw disk path" in r for r in reasons))
+
+    def test_exact_target_confirmation_required(self):
+        self.valid_request["target_confirmation"] = r"\\.\PHYSICALDRIVE2"
+        is_valid, reasons = validate_physical_usb_write_lab_gates(self.valid_request)
+        self.assertFalse(is_valid)
+        self.assertTrue(any("confirmation mismatch" in r for r in reasons))
+
+    def test_fresh_rescan_match_required(self):
+        self.valid_request["fresh_rescan_match"] = False
+        is_valid, reasons = validate_physical_usb_write_lab_gates(self.valid_request)
+        self.assertFalse(is_valid)
+        self.assertTrue(any("Fresh target re-scan" in r for r in reasons))
+
     def test_linux_platform_blocks(self):
         self.valid_request["platform"] = "linux"
         is_valid, reasons = validate_physical_usb_write_lab_gates(self.valid_request)
@@ -270,7 +307,7 @@ class TestPhysicalUSBWriteLabAdapter(unittest.TestCase):
     def _build_valid_request(self):
         return build_physical_usb_write_lab_request(
             platform="win32",
-            target_drive="E:\\",
+            target_drive=r"\\.\PHYSICALDRIVE1",
             target_stable_id="usb_stable_001",
             target_identity_hash="hash_abc",
             latest_identity_hash="hash_abc",
@@ -291,6 +328,21 @@ class TestPhysicalUSBWriteLabAdapter(unittest.TestCase):
             environment_unlock_present=True,
             running_as_admin_or_root=True,
             physical_write_requested=True,
+            verify_after_write=True,
+            target_confirmation=r"\\.\PHYSICALDRIVE1",
+            target_is_removable=True,
+            target_is_external=True,
+            target_is_fixed=False,
+            target_is_system_drive=False,
+            target_size_bytes=1000000000,
+            scanner_confidence="high",
+            fresh_rescan_match=True,
+            dryrun_wrote_zero_bytes=True,
+            evidence_target_matches=True,
+            evidence_image_matches=True,
+            audit_passed=True,
+            simulation_passed=True,
+            physical_write_max_bytes=5242880,
         )
 
     def test_adapter_name(self):
@@ -305,28 +357,33 @@ class TestPhysicalUSBWriteLabAdapter(unittest.TestCase):
             result["next_required_action"], "resolve_physical_write_blockers"
         )
 
-    def test_adapter_returns_not_safely_implemented(self):
+    @patch("real_writer_interface._execute_windows_physical_usb_write")
+    def test_adapter_invokes_windows_writer_after_all_gates(self, mock_execute):
+        mock_execute.return_value = {"blocked": False, "bytes_written": 5242880}
         req = self._build_valid_request()
         result = self.adapter.execute_write(req)
-        self.assertTrue(result["blocked"])
-        self.assertFalse(result["physical_write_attempted"])
-        self.assertIn("physical_writer_not_safely_implemented", result["block_reasons"])
-        self.assertEqual(
-            result["next_required_action"], "implement_safe_physical_writer"
-        )
+        self.assertFalse(result["blocked"])
+        mock_execute.assert_called_once()
 
-    def test_adapter_never_sets_write_attempted_true(self):
+    def test_adapter_does_not_write_when_gates_fail(self):
         req = self._build_valid_request()
+        req["fresh_rescan_match"] = False
         result = self.adapter.execute_write(req)
         self.assertFalse(result["physical_write_attempted"])
         self.assertFalse(result["physical_write_allowed"])
         self.assertEqual(result["bytes_written"], 0)
         self.assertEqual(result["chunks_written"], 0)
 
-    def test_adapter_preserves_target_info(self):
+    @patch("real_writer_interface._execute_windows_physical_usb_write")
+    def test_adapter_preserves_target_info(self, mock_execute):
+        mock_execute.return_value = {
+            "target_drive": r"\\.\PHYSICALDRIVE1",
+            "target_stable_id": "usb_stable_001",
+            "adapter": "physical-usb-write-lab",
+        }
         req = self._build_valid_request()
         result = self.adapter.execute_write(req)
-        self.assertEqual(result["target_drive"], "E:\\")
+        self.assertEqual(result["target_drive"], r"\\.\PHYSICALDRIVE1")
         self.assertEqual(result["target_stable_id"], "usb_stable_001")
         self.assertEqual(result["adapter"], "physical-usb-write-lab")
 
@@ -336,10 +393,10 @@ class TestPhysicalUSBWriteLabStatus(unittest.TestCase):
         status = build_physical_usb_write_lab_status()
         self.assertEqual(status["schema"], "bootforge.physical_usb_write_lab_status.v1")
 
-    def test_status_always_blocked(self):
+    def test_status_unarmed_by_default(self):
         status = build_physical_usb_write_lab_status()
         self.assertTrue(status["blocked"])
-        self.assertFalse(status["physical_write_implemented"])
+        self.assertTrue(status["physical_write_implemented"])
         self.assertFalse(status["physical_write_allowed"])
 
     def test_status_dashboard_write_blocked(self):
@@ -361,8 +418,37 @@ class TestPhysicalUSBWriteLabStatus(unittest.TestCase):
     def test_status_next_action(self):
         status = build_physical_usb_write_lab_status()
         self.assertEqual(
-            status["next_required_action"], "implement_safe_physical_writer"
+            status["next_required_action"], "satisfy_cli_physical_write_gates"
         )
+
+
+class TestPhysicalUSBWriteEngine(unittest.TestCase):
+    def test_copy_engine_writes_exact_image_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = os.path.join(tmp, "image.bin")
+            target_path = os.path.join(tmp, "target.bin")
+            payload = (b"phoenix-key" * 1000) + b"!"
+            with open(image_path, "wb") as image:
+                image.write(payload)
+            with open(target_path, "w+b") as target:
+                written = _write_image_to_seekable_target(image_path, target, 257)
+                target.seek(0)
+                self.assertEqual(target.read(), payload)
+            self.assertEqual(written, len(payload))
+
+    def test_short_write_reports_partial_byte_count(self):
+        class ShortTarget(io.BytesIO):
+            def write(self, data):
+                super().write(data[:3])
+                return 3
+
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = os.path.join(tmp, "image.bin")
+            with open(image_path, "wb") as image:
+                image.write(b"0123456789")
+            with self.assertRaises(RawWriteError) as raised:
+                _write_image_to_seekable_target(image_path, ShortTarget(), 10)
+            self.assertEqual(raised.exception.bytes_written, 3)
 
 
 class TestPhysicalUSBWriteLabExportPath(unittest.TestCase):

--- a/usb_creator.py
+++ b/usb_creator.py
@@ -1929,6 +1929,11 @@ if __name__ == "__main__":
         help="Export write plan audit as JSON to a local path",
     )
     parser.add_argument(
+        "--export-write-plan-json",
+        type=str,
+        help="Export the read-only plan receipt to a new local JSON file",
+    )
+    parser.add_argument(
         "--export-markdown",
         type=str,
         help="Export human-readable audit summary as Markdown to a local path",
@@ -1940,6 +1945,11 @@ if __name__ == "__main__":
         "--mock-cancel-at-chunk",
         type=int,
         help="Cancel mock simulation at chunk number",
+    )
+    parser.add_argument(
+        "--export-mock-write-json",
+        type=str,
+        help="Export the non-destructive mock writer receipt to a new local JSON file",
     )
     parser.add_argument(
         "--download-oclp",
@@ -1989,6 +1999,11 @@ if __name__ == "__main__":
         "--lock-removable-target",
         action="store_true",
         help="Build deterministic removable target identity lock record",
+    )
+    parser.add_argument(
+        "--export-identity-lock-json",
+        type=str,
+        help="Export the removable target identity lock to a new local JSON file",
     )
     parser.add_argument(
         "--rescan-target-identity",
@@ -2065,9 +2080,24 @@ if __name__ == "__main__":
         help="Maximum bytes to write in physical USB write lab",
     )
     parser.add_argument(
+        "--confirm-physical-target",
+        type=str,
+        help="Re-enter the exact \\\\.\\PHYSICALDRIVE<n> target immediately before physical write",
+    )
+    parser.add_argument(
         "--require-dryrun-result",
         type=str,
         help="Path to JSON dry-run result required for physical write lab",
+    )
+    parser.add_argument(
+        "--require-audit-result",
+        type=str,
+        help="Path to required passed write-plan audit JSON for physical write lab",
+    )
+    parser.add_argument(
+        "--require-simulation-result",
+        type=str,
+        help="Path to required completed mock-writer JSON for physical write lab",
     )
     parser.add_argument(
         "--require-preflight-result",
@@ -2207,6 +2237,8 @@ if __name__ == "__main__":
         lock_data = None
         preflight_data = None
         dryrun_data = None
+        audit_data = None
+        simulation_data = None
 
         if args.require_identity_lock and os.path.exists(args.require_identity_lock):
             with open(args.require_identity_lock, "r") as f:
@@ -2219,12 +2251,133 @@ if __name__ == "__main__":
         if args.require_dryrun_result and os.path.exists(args.require_dryrun_result):
             with open(args.require_dryrun_result, "r") as f:
                 dryrun_data = json.load(f)
+        if args.require_audit_result and os.path.exists(args.require_audit_result):
+            with open(args.require_audit_result, "r") as f:
+                audit_data = json.load(f)
+        if args.require_simulation_result and os.path.exists(
+            args.require_simulation_result
+        ):
+            with open(args.require_simulation_result, "r") as f:
+                simulation_data = json.load(f)
+
+        # Receipts are evidence, not authority. Re-scan the actual machine and
+        # compare the live target identity immediately before any raw handle opens.
+        fresh_scan = get_normalized_scan(quiet=True)
+        live_device = None
+        normalized_target = args.target_drive.lower().rstrip("\\/")
+        for device in fresh_scan.get("devices", []):
+            if (device.get("drive_path") or "").lower().rstrip(
+                "\\/"
+            ) == normalized_target:
+                live_device = device
+                break
+
+        rescan_result = None
+        if lock_data:
+            from real_writer_interface import rescan_and_compare_target_identity
+
+            rescan_result = rescan_and_compare_target_identity(lock_data, fresh_scan)
+
+        evidence_target_matches = bool(
+            lock_data
+            and preflight_data
+            and dryrun_data
+            and lock_data.get("schema") == "bootforge.removable_target_identity_lock.v1"
+            and lock_data.get("blocked") is False
+            and preflight_data.get("schema") == "bootforge.hardware_writer_preflight.v1"
+            and preflight_data.get("identity_lock_passed") is True
+            and (lock_data.get("target_drive") or "").lower().rstrip("\\/")
+            == normalized_target
+            and (preflight_data.get("target_drive") or "").lower().rstrip("\\/")
+            == normalized_target
+            and (dryrun_data.get("target_drive") or "").lower().rstrip("\\/")
+            == normalized_target
+            and preflight_data.get("target_identity_hash")
+            == lock_data.get("device_identity_hash")
+        )
 
         image_sha = None
         image_size = 0
         if os.path.exists(args.image):
             image_sha = calculate_file_sha256(args.image)
             image_size = os.path.getsize(args.image)
+
+        preflight_image_sha = (
+            preflight_data.get("image_sha256") if preflight_data else None
+        )
+        dryrun_image_sha = None
+        if dryrun_data:
+            dryrun_image_sha = (
+                ((dryrun_data.get("image_inspection") or {}).get("image") or {}).get(
+                    "sha256"
+                )
+                or dryrun_data.get("image_sha256")
+                or dryrun_data.get("image_sha256_expected")
+            )
+        evidence_image_matches = bool(
+            image_sha
+            and preflight_image_sha == image_sha
+            and dryrun_image_sha == image_sha
+        )
+
+        dryrun_wrote_zero_bytes = bool(
+            dryrun_data
+            and dryrun_data.get("schema") == "bootforge.write_plan.v1"
+            and dryrun_data.get("blocked") is False
+            and dryrun_data.get("bytes_written", 0) == 0
+            and dryrun_data.get("physical_write_attempted", False) is False
+            and dryrun_data.get("actual_write_enabled", False) is False
+        )
+        dryrun_receipt_id = (
+            "plan_"
+            + hashlib.sha256(
+                json.dumps(dryrun_data, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()[:32]
+            if dryrun_data
+            else None
+        )
+        audit_passed = bool(
+            audit_data
+            and audit_data.get("schema") == "bootforge.write_plan_audit.v1"
+            and audit_data.get("validation_status") == "passed"
+            and audit_data.get("blocked") is False
+            and audit_data.get("actual_write_enabled", False) is False
+            and (audit_data.get("target_drive") or "").lower().rstrip("\\/")
+            == normalized_target
+            and (
+                (
+                    (
+                        (audit_data.get("write_plan") or {}).get("image_inspection")
+                        or {}
+                    ).get("image")
+                    or {}
+                ).get("sha256")
+                == image_sha
+            )
+        )
+        simulation_passed = bool(
+            simulation_data
+            and simulation_data.get("schema") == "bootforge.mock_writer.v1"
+            and simulation_data.get("status") == "completed"
+            and simulation_data.get("blocked") is False
+            and simulation_data.get("actual_write_enabled") is False
+            and simulation_data.get("bytes_simulated")
+            == simulation_data.get("total_bytes")
+            and (simulation_data.get("target_drive") or "").lower().rstrip("\\/")
+            == normalized_target
+            and (
+                (
+                    (
+                        (
+                            (simulation_data.get("audit") or {}).get("write_plan") or {}
+                        ).get("image_inspection")
+                        or {}
+                    ).get("image")
+                    or {}
+                ).get("sha256")
+                == image_sha
+            )
+        )
 
         req = build_physical_usb_write_lab_request(
             platform=sys.platform,
@@ -2234,12 +2387,25 @@ if __name__ == "__main__":
                 lock_data.get("device_identity_hash") if lock_data else None
             ),
             latest_identity_hash=(
-                lock_data.get("device_identity_hash") if lock_data else None
+                rescan_result.get("latest_identity_hash") if rescan_result else None
             ),
             identity_lock_id=lock_data.get("identity_lock_id") if lock_data else None,
             preflight_id=preflight_data.get("preflight_id") if preflight_data else None,
-            dryrun_result_id=dryrun_data.get("result_id") if dryrun_data else None,
-            readiness_gate_id=dryrun_data.get("request_id") if dryrun_data else None,
+            dryrun_result_id=(
+                dryrun_data.get("result_id")
+                or dryrun_data.get("plan_id")
+                or dryrun_receipt_id
+                if dryrun_data
+                else None
+            ),
+            readiness_gate_id=(
+                dryrun_data.get("readiness_gate_id")
+                or dryrun_data.get("request_id")
+                or dryrun_data.get("plan_id")
+                or dryrun_receipt_id
+                if dryrun_data
+                else None
+            ),
             session_id=lock_data.get("identity_lock_id") if lock_data else None,
             ledger_path=args.append_writer_contract_ledger,
             image_path=args.image,
@@ -2256,6 +2422,30 @@ if __name__ == "__main__":
             verify_after_write=args.verify_after_write,
             physical_write_requested=True,
             physical_write_allowed=False,
+            target_confirmation=args.confirm_physical_target,
+            target_is_removable=(
+                live_device.get("is_removable", False) if live_device else False
+            ),
+            target_is_external=(
+                live_device.get("is_external", False) if live_device else False
+            ),
+            target_is_fixed=(
+                live_device.get("is_fixed", True) if live_device else True
+            ),
+            target_is_system_drive=(
+                live_device.get("is_system", True) if live_device else True
+            ),
+            target_size_bytes=(live_device.get("size_bytes", 0) if live_device else 0),
+            scanner_confidence=(live_device.get("confidence") if live_device else None),
+            fresh_rescan_match=bool(
+                rescan_result and rescan_result.get("match") is True
+            ),
+            dryrun_wrote_zero_bytes=dryrun_wrote_zero_bytes,
+            evidence_target_matches=evidence_target_matches,
+            evidence_image_matches=evidence_image_matches,
+            audit_passed=audit_passed,
+            simulation_passed=simulation_passed,
+            physical_write_max_bytes=args.physical_write_max_bytes,
         )
 
         adapter = PhysicalUSBWriteLabAdapter()
@@ -2363,7 +2553,9 @@ if __name__ == "__main__":
                 print(json.dumps(res, indent=2))
                 sys.exit(1)
 
-            lock = build_removable_target_identity_lock(args.target_drive)
+            lock = build_removable_target_identity_lock(
+                args.target_drive, get_normalized_scan(quiet=True)
+            )
             if lock.get("blocked"):
                 res = {
                     "schema": "bootforge.physical_writer_dryrun_result.v1",
@@ -2490,15 +2682,26 @@ if __name__ == "__main__":
         print(json.dumps(res, indent=2))
         sys.exit(0)
     elif args.lock_removable_target:
-        from real_writer_interface import build_removable_target_identity_lock
+        from real_writer_interface import (
+            build_removable_target_identity_lock,
+            validate_hardware_preflight_export_path,
+        )
 
-        lock = build_removable_target_identity_lock(args.target_drive)
+        lock = build_removable_target_identity_lock(
+            args.target_drive, get_normalized_scan(quiet=True)
+        )
         # Optional ledger append if requested
         ledger_path = args.append_writer_contract_ledger
         if ledger_path:
             from writer_safety_contract import append_writer_contract_ledger_record
 
             append_writer_contract_ledger_record(lock, ledger_path)
+        if args.export_identity_lock_json:
+            validate_hardware_preflight_export_path(
+                args.export_identity_lock_json, "json", args.target_drive
+            )
+            with open(args.export_identity_lock_json, "w", encoding="utf-8") as f:
+                json.dump(lock, f, indent=2)
         print(json.dumps(lock, indent=2))
         sys.exit(0)
     elif args.rescan_target_identity:
@@ -2507,10 +2710,10 @@ if __name__ == "__main__":
             rescan_and_compare_target_identity,
         )
 
-        lock = build_removable_target_identity_lock(args.target_drive)
-        # Mock scan payload
-        drives = get_removable_drives()
-        scan_payload = {"drives": drives}
+        lock = build_removable_target_identity_lock(
+            args.target_drive, get_normalized_scan(quiet=True)
+        )
+        scan_payload = get_normalized_scan(quiet=True)
         cmp_res = rescan_and_compare_target_identity(lock, scan_payload)
         print(json.dumps(cmp_res, indent=2))
         sys.exit(0)
@@ -2522,7 +2725,9 @@ if __name__ == "__main__":
             export_hardware_preflight_markdown,
         )
 
-        lock = build_removable_target_identity_lock(args.target_drive)
+        lock = build_removable_target_identity_lock(
+            args.target_drive, get_normalized_scan(quiet=True)
+        )
         image_payload = None
         if args.image:
             image_payload = {
@@ -2692,12 +2897,19 @@ if __name__ == "__main__":
                 )
             )
         else:
-            print_mock_writer_json(
+            simulation = build_mock_writer_payload(
                 args.target_drive,
                 args.image,
                 fail_at_chunk=args.mock_fail_at_chunk,
                 cancel_at_chunk=args.mock_cancel_at_chunk,
             )
+            if args.export_mock_write_json:
+                validate_export_safety(
+                    args.export_mock_write_json, args.target_drive, "json"
+                )
+                with open(args.export_mock_write_json, "w", encoding="utf-8") as f:
+                    json.dump(simulation, f, indent=2)
+            print(json.dumps(simulation, indent=2))
     elif args.audit_plan:
         if not args.target_drive or not args.image:
             print(
@@ -2756,7 +2968,14 @@ if __name__ == "__main__":
                 )
             )
         else:
-            print_write_plan_json(args.target_drive, args.image)
+            plan = build_write_plan_payload(args.target_drive, args.image)
+            if args.export_write_plan_json:
+                validate_export_safety(
+                    args.export_write_plan_json, args.target_drive, "json"
+                )
+                with open(args.export_write_plan_json, "w", encoding="utf-8") as f:
+                    json.dump(plan, f, indent=2)
+            print(json.dumps(plan, indent=2))
     elif args.inspect_image:
         print_image_inspection_json(args.inspect_image)
     elif args.inspect_drive:


### PR DESCRIPTION
Adds a CLI-only Windows physical USB write lab on top of the dry-run foundation.

Safety scope:
- exact `\\.\PHYSICALDRIVE<n>` targets only
- live removable/external scanner proof
- fixed, internal, boot, and system targets blocked
- fresh identity re-scan must match the saved lock
- identity-lock, preflight, plan, audit, and simulation receipts required
- current image SHA-256 must match every receipt
- exact image-size byte cap and three typed confirmations
- exact target re-entry
- elevated Windows process and explicit environment unlock
- durable pre/post ledger receipts
- exclusive Windows raw-disk handle; mounted/busy targets fail closed
- full read-back SHA-256 verification
- no dashboard write control; macOS/Linux remain blocked

Verification:
- 101 focused scanner/writer tests passed
- critical Flake8 passed
- Black passed on changed Python files
- Phoenix Key repository boundary check passed
- Phoenix Key frontend build passed

This PR is intentionally draft and targets `usb-creator-foundation-lock`, not `main`. No physical hardware write has been executed by CI or Codex. Windows sacrificial-drive validation is required before any promotion.