### PR TITLE
Fan-favorite foundation: canonical entry point, product boundaries, and CI

### DIFF
--- a/.github/workflows/fan-favorite-foundation.yml
+++ b/.github/workflows/fan-favorite-foundation.yml
@@ -1,0 +1,104 @@
+name: Fan-Favorite Foundation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - polish/fan-favorite-foundation
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phoenixcore-foundation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-foundation:
+    name: Python foundation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile Python sources
+        run: python -m compileall -q usb_creator.py tests
+
+      - name: Run Python unit tests
+        run: python -m unittest discover -s tests -p "test_*.py" -v
+
+      - name: Detect known fail-open registry blocker
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path("usb_creator.py").read_text(encoding="utf-8")
+          marker = 'Registry unavailable. Standard validation bypassed'
+          fail_open = marker in source and "return True" in source[source.index(marker):source.index(marker) + 300]
+          if fail_open:
+              print("::warning file=usb_creator.py::Known blocker: missing registry can still return approval. Issue #125 blocks release promotion until this fails closed and has a regression test.")
+              Path("phoenixcore-security-blockers.txt").write_text(
+                  "FAIL_OPEN_REGISTRY_VALIDATION=present\n"
+                  "TRACKING_ISSUE=https://github.com/Bboy9090/PhoenixCore-/issues/125\n",
+                  encoding="utf-8",
+              )
+          else:
+              Path("phoenixcore-security-blockers.txt").write_text(
+                  "FAIL_OPEN_REGISTRY_VALIDATION=not_detected\n",
+                  encoding="utf-8",
+              )
+          PY
+
+      - name: Upload Python foundation evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: phoenixcore-python-foundation
+          path: phoenixcore-security-blockers.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  dashboard-foundation:
+    name: Dashboard lint and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: dashboard
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Lint dashboard
+        run: npm run lint
+
+      - name: Build dashboard
+        run: npm run build
+
+      - name: Upload dashboard build
+        uses: actions/upload-artifact@v4
+        with:
+          name: phoenixcore-dashboard-build
+          path: dashboard/dist
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/fan-favorite-foundation.yml
+++ b/.github/workflows/fan-favorite-foundation.yml
@@ -30,50 +30,77 @@ jobs:
           python-version: "3.11"
 
       - name: Compile Python sources
-        run: python -m compileall -q usb_creator.py tests
+        id: compile
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m compileall -q usb_creator.py tests 2>&1 | tee python-compile.log
 
       - name: Run Python unit tests
-        run: python -m unittest discover -s tests -p "test_*.py" -v
+        id: tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m unittest discover -s tests -p "test_*.py" -v 2>&1 | tee python-tests.log
 
       - name: Detect known fail-open registry blocker
+        if: always()
         shell: bash
         run: |
           python - <<'PY'
           from pathlib import Path
 
           source = Path("usb_creator.py").read_text(encoding="utf-8")
-          marker = 'Registry unavailable. Standard validation bypassed'
-          fail_open = marker in source and "return True" in source[source.index(marker):source.index(marker) + 300]
+          marker = "Registry unavailable. Standard validation bypassed"
+          start = source.find(marker)
+          fail_open = start >= 0 and "return True" in source[start:start + 300]
           if fail_open:
               print("::warning file=usb_creator.py::Known blocker: missing registry can still return approval. Issue #125 blocks release promotion until this fails closed and has a regression test.")
-              Path("phoenixcore-security-blockers.txt").write_text(
-                  "FAIL_OPEN_REGISTRY_VALIDATION=present\n"
-                  "TRACKING_ISSUE=https://github.com/Bboy9090/PhoenixCore-/issues/125\n",
-                  encoding="utf-8",
-              )
+              state = "present"
           else:
-              Path("phoenixcore-security-blockers.txt").write_text(
-                  "FAIL_OPEN_REGISTRY_VALIDATION=not_detected\n",
-                  encoding="utf-8",
-              )
+              state = "not_detected"
+          Path("phoenixcore-security-blockers.txt").write_text(
+              f"FAIL_OPEN_REGISTRY_VALIDATION={state}\n"
+              "TRACKING_ISSUE=https://github.com/Bboy9090/PhoenixCore-/issues/125\n",
+              encoding="utf-8",
+          )
           PY
 
+      - name: Record Python step outcomes
+        if: always()
+        shell: bash
+        run: |
+          printf '%s\n' \
+            "compile_outcome=${{ steps.compile.outcome }}" \
+            "tests_outcome=${{ steps.tests.outcome }}" \
+            > python-step-outcomes.txt
+
       - name: Upload Python foundation evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: phoenixcore-python-foundation
-          path: phoenixcore-security-blockers.txt
+          path: |
+            python-compile.log
+            python-tests.log
+            python-step-outcomes.txt
+            phoenixcore-security-blockers.txt
           if-no-files-found: error
           retention-days: 14
+
+      - name: Enforce Python foundation gate
+        if: always()
+        shell: bash
+        run: |
+          test "${{ steps.compile.outcome }}" = "success"
+          test "${{ steps.tests.outcome }}" = "success"
 
   dashboard-foundation:
     name: Dashboard lint and build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
-    defaults:
-      run:
-        working-directory: dashboard
 
     steps:
       - name: Check out source
@@ -87,18 +114,62 @@ jobs:
           cache-dependency-path: dashboard/package-lock.json
 
       - name: Install locked dependencies
-        run: npm ci
+        id: install
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          cd dashboard
+          npm ci 2>&1 | tee ../dashboard-install.log
 
       - name: Lint dashboard
-        run: npm run lint
+        id: lint
+        if: steps.install.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          cd dashboard
+          npm run lint 2>&1 | tee ../dashboard-lint.log
 
       - name: Build dashboard
-        run: npm run build
+        id: build
+        if: steps.install.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          cd dashboard
+          npm run build 2>&1 | tee ../dashboard-build.log
 
-      - name: Upload dashboard build
+      - name: Record dashboard step outcomes
+        if: always()
+        shell: bash
+        run: |
+          printf '%s\n' \
+            "install_outcome=${{ steps.install.outcome }}" \
+            "lint_outcome=${{ steps.lint.outcome }}" \
+            "build_outcome=${{ steps.build.outcome }}" \
+            > dashboard-step-outcomes.txt
+
+      - name: Upload dashboard evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: phoenixcore-dashboard-build
-          path: dashboard/dist
-          if-no-files-found: error
+          name: phoenixcore-dashboard-foundation
+          path: |
+            dashboard-install.log
+            dashboard-lint.log
+            dashboard-build.log
+            dashboard-step-outcomes.txt
+            dashboard/dist
+          if-no-files-found: warn
           retention-days: 14
+
+      - name: Enforce dashboard foundation gate
+        if: always()
+        shell: bash
+        run: |
+          test "${{ steps.install.outcome }}" = "success"
+          test "${{ steps.lint.outcome }}" = "success"
+          test "${{ steps.build.outcome }}" = "success"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,145 @@
+# PhoenixCore
+
+**Device intelligence, diagnostics, recovery planning, and evidence orchestration for Bobby’s Workshop.**
+
+PhoenixCore helps an authorized owner or technician understand a connected device, identify its current mode and supported capabilities, and produce a cautious recovery plan before any mutation is considered.
+
+## Current maturity
+
+**Status: prototype with tested read-only and dry-run foundations.**
+
+This repository contains working code and tests, but it is not yet a production device-repair platform. It does not currently carry a general hardware-support, physical-write, firmware-flashing, bypass, or production-readiness claim.
+
+## Supported foundation
+
+The clearest currently testable path is the Python USB/rescue-planning module plus the React dashboard:
+
+- cross-platform removable-device enumeration
+- SHA-256 file identity calculation
+- signed tool-registry loading and tamper rejection
+- registered tool URL and checksum comparison
+- dry-run rescue-directory planning
+- non-destructive directory-structure creation on an explicitly supplied mounted path
+- dashboard development, lint, and production build commands
+
+The active fan-favorite foundation issue is [#125](https://github.com/Bboy9090/PhoenixCore-/issues/125).
+
+## Important safety blocker
+
+`usb_creator.validate_tool_against_registry()` currently returns success when the registry loader returns no registry. That is a **fail-open behavior** and is not accepted as a production security boundary.
+
+Until it is corrected and regression-tested:
+
+- do not treat registry validation as authoritative when the manifest is unavailable
+- do not use this code to approve downloads or physical device mutation
+- do not describe the tool supply chain as fully fail-closed
+
+The portfolio standard requires missing, invalid, ambiguous, or unsupported trust evidence to block approval.
+
+## Quick start
+
+### Python foundation
+
+Requirements:
+
+- Python 3.11 or newer
+- platform utilities used by the selected read-only scanner, such as `lsblk` on Linux or `diskutil` on macOS
+
+Run the test suite:
+
+```bash
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+List detected removable devices without mutation:
+
+```bash
+python usb_creator.py --list
+```
+
+Simulate the rescue-directory plan without writing files:
+
+```bash
+python usb_creator.py --create /path/to/mounted/target --dry-run
+```
+
+The non-dry-run `--create` path creates folders and a text README on the supplied mounted target. It is not a disk imager, partitioner, formatter, bootloader installer, or firmware writer.
+
+### Dashboard
+
+Requirements:
+
+- Node.js compatible with the locked Vite toolchain
+- npm
+
+```bash
+cd dashboard
+npm ci
+npm run lint
+npm run build
+npm run dev
+```
+
+Browser data must be labeled as live, fixture, or sample data. A successful frontend render is not hardware validation.
+
+## Product boundaries
+
+PhoenixCore owns:
+
+- device identity and mode interpretation
+- read-only diagnostics
+- capability and limitation analysis
+- recovery-plan generation
+- evidence and receipt orchestration
+- cross-device coordination contracts
+
+PhoenixCore does not own:
+
+- the ARCWYRE Native kernel or operating system
+- BootForge’s reusable low-level USB primitives
+- Phoenix Key’s end-user boot-media experience
+- Bobby’s Workshop’s complete technician workspace
+- hidden bypass, lock removal, unauthorized access, or unsupported destructive actions
+
+See [`docs/PRODUCT_BOUNDARIES.md`](docs/PRODUCT_BOUNDARIES.md).
+
+## Repository truth rules
+
+1. A feature is supported only when the documented command, test, and evidence exist.
+2. Fixture or sample data is never presented as live hardware data.
+3. Dry-run success is not a physical-write receipt.
+4. QEMU or mocked tests are not hardware validation.
+5. Missing trust, identity, permission, or target evidence fails closed.
+6. Historical plans and recovered prototypes do not override current machine evidence.
+
+## Quality gates
+
+The foundation workflow is intended to verify:
+
+- Python compilation
+- Python unit tests
+- dashboard locked dependency installation
+- dashboard lint
+- dashboard production build
+- explicit detection of the current fail-open registry blocker
+
+A passing foundation workflow proves only those gates. It does not prove production readiness or hardware support.
+
+## Documentation
+
+- [Product boundaries](docs/PRODUCT_BOUNDARIES.md)
+- [Known limitations](docs/KNOWN_LIMITATIONS.md)
+- [Fan-favorite foundation issue](https://github.com/Bboy9090/PhoenixCore-/issues/125)
+- [Portfolio program](https://github.com/Bboy9090/Bboy9090/issues/4)
+
+## Security
+
+Do not report sensitive device data, credentials, private keys, account tokens, personal identifiers, or proprietary firmware in public issues. Security-sensitive reports should include the smallest reproducible description and omit user data.
+
+A dedicated security policy and supported disclosure channel remain part of the foundation issue before release promotion.
+
+## License and third-party tools
+
+Third-party recovery utilities retain their own licenses, support boundaries, trademarks, and distribution rules. A registry entry or integration plan does not transfer ownership, certify safety, or grant redistribution rights.
+
+PhoenixCore must preserve source provenance and verify every external artifact through the strongest supported upstream mechanism before use.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -1,0 +1,58 @@
+# Known Limitations
+
+This file records current limitations of the PhoenixCore foundation. It is intentionally stricter than historical plans or feature checklists.
+
+## Trust and registry validation
+
+- `validate_tool_against_registry()` currently returns success when no registry object is available.
+- This is fail-open behavior and blocks any production trust claim.
+- The repository contains a direct Python Ed25519 implementation that requires independent review and replacement or validation against a maintained cryptographic library before release promotion.
+- A registered URL and SHA-256 value do not by themselves prove upstream publisher identity or package signing.
+
+## Device discovery
+
+- Windows discovery currently enumerates logical removable/CD-ROM volumes rather than proving an immutable whole-disk identity.
+- Linux discovery relies on `lsblk` output and removable flags; it does not yet retain a complete hardware identity receipt.
+- macOS discovery uses `diskutil` and broad removable/external fields; edge cases require named-hardware tests.
+- Scanner output does not by itself authorize planning or mutation.
+
+## Rescue structure creation
+
+- `create_rescue_usb_structure()` creates directories and a README on an existing mounted path.
+- It does not partition, format, image, install a bootloader, write firmware, or prove bootability.
+- The supplied path is not yet bound to a prior immutable target-identity receipt.
+- Dry-run mode proves only that the planning code completed without writing.
+
+## External tool retrieval
+
+- The OCLP retrieval path depends on GitHub release metadata and current registry values.
+- Network behavior is mocked in unit tests; the tests do not prove current upstream availability, publisher signature validity, or redistribution rights.
+- The current domain-string check is not a complete URL-origin or redirect security policy.
+
+## Dashboard
+
+- A successful Vite build proves compilation, not live-device integration.
+- Browser previews may contain fixture or sample data and must label it clearly.
+- Accessibility, responsive behavior, performance budgets, and complete failure states are not yet evidenced.
+
+## Repository state
+
+- The repository is unusually large and may contain duplicate assets, generated output, recovered prototypes, and historical planning material.
+- A canonical supported source tree has not yet been declared.
+- Root-level dependency, build, test, security, release, and support policies remain incomplete.
+
+## Unsupported claims
+
+PhoenixCore does not currently claim:
+
+- production readiness
+- general hardware compatibility
+- physical disk-write safety
+- bootable-media creation
+- firmware flashing
+- account, activation, carrier, bootloader, or security bypass
+- hardware validation across Windows, macOS, or Linux
+- independent security review
+- reproducible release artifacts
+
+These limitations remain active until machine evidence and reviewed documentation explicitly replace them.

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -1,0 +1,70 @@
+# PhoenixCore Product Boundaries
+
+## Purpose
+
+PhoenixCore is the device-intelligence and recovery-planning layer in the Bobby’s Workshop ecosystem. Its job is to convert read-only device facts into understandable capabilities, limitations, risks, recommended next steps, and retained evidence.
+
+It is deliberately not the entire ecosystem.
+
+## Ownership map
+
+| Product | Owns | Does not own |
+|---|---|---|
+| ARCWYRE Native | From-scratch kernel, userspace, native services, operating-system security and recovery | General cross-platform workshop UI or third-party OS imaging |
+| PhoenixCore | Device intelligence, diagnostics, plan generation, evidence orchestration, coordination contracts | Kernel, low-level USB library, complete repair desktop, or boot-media UI |
+| BootForge | Reusable low-level USB discovery, enumeration, target identity, and carefully gated boot primitives | Complete technician workflow or diagnostic policy |
+| Phoenix Key | End-user boot and recovery media experience powered by approved lower-level contracts | Silent target selection, hidden bypass, or unsupported writes |
+| Bobby’s Workshop | Technician-facing cases, notes, guided workflows, approvals, reports, and integrated user experience | Reimplementation of every lower-level engine inside one repository |
+
+## PhoenixCore responsibilities
+
+PhoenixCore may:
+
+- accept normalized read-only observations from supported adapters
+- identify device family, connection mode, and confidence
+- report missing or conflicting evidence
+- calculate supported diagnostic capabilities
+- recommend owner-authorized recovery paths
+- produce machine-readable plans and evidence receipts
+- coordinate with Phoenix Key and Bobby’s Workshop through versioned contracts
+
+PhoenixCore must not:
+
+- claim exact hardware identity from insufficient evidence
+- authorize an operation because a fixture or mock succeeded
+- treat a missing trust registry as approval
+- select a physical write target silently
+- bypass ownership, activation, account, firmware, bootloader, carrier, or platform security controls
+- claim support for a platform merely because related code or documentation exists
+
+## Contract rules
+
+Every cross-repository contract must define:
+
+- schema name and version
+- producer and consumer
+- required and optional fields
+- identity and provenance fields
+- confidence and limitation fields
+- error model
+- compatibility policy
+- test fixtures
+- migration and deprecation policy
+
+Repositories may share versioned low-level libraries. They must not silently copy security-sensitive source and allow it to drift.
+
+## Evidence ownership
+
+- BootForge records low-level device and transport facts.
+- PhoenixCore records diagnostic interpretation and planning facts.
+- Phoenix Key records media-planning and approved write facts.
+- Bobby’s Workshop records human approval, case activity, and technician-facing reports.
+- ARCWYRE records native boot, kernel, userspace, and operating-system evidence.
+
+Each layer preserves upstream identities rather than rewriting them into a single vague “success” event.
+
+## Current boundary decision
+
+The current repository is treated as a prototype collection while the canonical vertical slice is isolated. Existing modules, dashboards, plans, and recovered assets are not automatically part of the supported PhoenixCore surface.
+
+Issue [#125](https://github.com/Bboy9090/PhoenixCore-/issues/125) owns the initial supported-surface decision.


### PR DESCRIPTION
## Purpose

Create a truthful, testable front door for PhoenixCore before broader UX and feature polish.

## Changes

- add a canonical root README with supported commands and explicit maturity
- document PhoenixCore, BootForge, Phoenix Key, Bobby’s Workshop, and ARCWYRE ownership boundaries
- record current known limitations and unsupported claims
- add root CI for Python compilation/tests and dashboard locked install/lint/build
- retain a machine-readable artifact that surfaces the known fail-open registry-validation blocker

## Security finding

`validate_tool_against_registry()` currently approves when the registry loader returns no registry. This PR does **not** hide or redefine that behavior. CI records it as a warning and issue #125 blocks release promotion until a patch-capable implementation pass changes it to fail closed and adds a regression test.

## Evidence scope

A green workflow proves only:

- Python source compilation
- current Python unit tests
- dashboard lint
- dashboard production build
- explicit detection of the current trust blocker

It does not prove hardware validation, physical writes, bootable media, firmware operations, production readiness, or independent security review.

## Tracking

- PhoenixCore issue: #125
- Portfolio program: https://github.com/Bboy9090/Bboy9090/issues/4
- Portfolio tracker: https://docs.google.com/spreadsheets/d/1ji4Jo_KuXCnbdhcwLYmgaaBGj3A9WLf5pH4qG7QuG7c/edit
