### PR TITLE
test(phoenix-key): prove Windows installer lifecycle

### DIFF
--- a/.github/workflows/phoenix-key-windows-lifecycle.yml
+++ b/.github/workflows/phoenix-key-windows-lifecycle.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: phoenix-key-windows-lifecycle-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-lifecycle-input:
     runs-on: windows-latest
@@ -29,6 +33,12 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/phoenix-key/src-tauri -> target
+          shared-key: phoenix-key-windows-lifecycle
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/phoenix-key-windows-lifecycle.yml
+++ b/.github/workflows/phoenix-key-windows-lifecycle.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Test source artifact receipt generator
+        run: npm run test:artifact-receipt
+
       - name: Test installed smoke receipt contract
         env:
           PHOENIX_KEY_SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -53,15 +56,67 @@ jobs:
           PHOENIX_KEY_SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: npm run desktop:build
 
-      - name: Upload lifecycle installer inputs
+      - name: Inspect and confirm unsigned lifecycle input state
+        shell: pwsh
+        run: |
+          $files = @()
+          $files += Get-ChildItem "src-tauri/target/release/bundle/msi/*.msi"
+          $files += Get-ChildItem "src-tauri/target/release/bundle/nsis/*.exe"
+          if ($files.Count -ne 2) {
+            throw "Expected exactly one MSI and one NSIS installer output; found $($files.Count)."
+          }
+
+          $allowedUnsignedProbeStates = @("NotSigned", "UnknownError")
+          $observations = @()
+          foreach ($file in $files) {
+            if ($file.Length -le 0) {
+              throw "Installer is empty: $($file.FullName)"
+            }
+
+            $signature = Get-AuthenticodeSignature -FilePath $file.FullName
+            $signerPresent = $null -ne $signature.SignerCertificate
+            $timestampPresent = $null -ne $signature.TimeStamperCertificate
+            Write-Host "SIGNATURE_PROBE file=$($file.Name) status=$($signature.Status) signer_present=$signerPresent timestamp_present=$timestampPresent message=$($signature.StatusMessage)"
+
+            if ($signerPresent -or $timestampPresent) {
+              throw "Lifecycle input unexpectedly carries a signer or timestamp certificate: $($file.Name)"
+            }
+            if ($allowedUnsignedProbeStates -notcontains [string]$signature.Status) {
+              throw "Lifecycle input signing state is neither unsigned nor format-unavailable for $($file.Name): $($signature.Status)"
+            }
+
+            $observations += [PSCustomObject]@{
+              filename = $file.Name
+              probe_status = [string]$signature.Status
+              probe_message = [string]$signature.StatusMessage
+              signer_present = $signerPresent
+              timestamp_present = $timestampPresent
+            }
+          }
+
+          $observationPath = "src-tauri/target/release/bundle/phoenix-key.signature-observation.json"
+          $observations | ConvertTo-Json -Depth 4 | Set-Content -Path $observationPath -Encoding utf8
+          Get-Content $observationPath
+
+      - name: Emit same-commit source artifact receipt
+        env:
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          PHOENIX_KEY_BUILD_WORKFLOW: Phoenix Key Windows Lifecycle
+          PHOENIX_KEY_BUILD_COMMAND: npm run desktop:build
+        run: node scripts/emit-artifact-receipt.mjs
+
+      - name: Upload lifecycle inputs and source receipt
         uses: actions/upload-artifact@v4
         with:
           name: phoenix-key-windows-lifecycle-inputs
           path: |
             apps/phoenix-key/src-tauri/target/release/bundle/msi/*.msi
             apps/phoenix-key/src-tauri/target/release/bundle/nsis/*.exe
+            apps/phoenix-key/src-tauri/target/release/bundle/phoenix-key.signature-observation.json
+            apps/phoenix-key/src-tauri/target/release/bundle/phoenix-key.source-artifact.json
+            apps/phoenix-key/src-tauri/target/release/bundle/phoenix-key.source-artifact.json.sha256
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 30
 
   installer-lifecycle:
     needs: build-lifecycle-input

--- a/.github/workflows/phoenix-key-windows-lifecycle.yml
+++ b/.github/workflows/phoenix-key-windows-lifecycle.yml
@@ -1,0 +1,107 @@
+name: Phoenix Key Windows Lifecycle
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "apps/phoenix-key/**"
+      - ".github/workflows/phoenix-key-windows-lifecycle.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-lifecycle-input:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: apps/phoenix-key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/phoenix-key/package-lock.json
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Test installed smoke receipt contract
+        env:
+          PHOENIX_KEY_SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Build MSI and NSIS lifecycle inputs
+        env:
+          PHOENIX_KEY_SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: npm run desktop:build
+
+      - name: Upload lifecycle installer inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: phoenix-key-windows-lifecycle-inputs
+          path: |
+            apps/phoenix-key/src-tauri/target/release/bundle/msi/*.msi
+            apps/phoenix-key/src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+          retention-days: 14
+
+  installer-lifecycle:
+    needs: build-lifecycle-input
+    runs-on: windows-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        installer_kind: [msi, nsis]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download lifecycle installer inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: phoenix-key-windows-lifecycle-inputs
+          path: lifecycle-inputs
+
+      - name: Locate installer
+        id: installer
+        shell: pwsh
+        run: |
+          if ("${{ matrix.installer_kind }}" -eq "msi") {
+            $matches = @(Get-ChildItem "lifecycle-inputs" -Recurse -File -Filter "*.msi")
+          }
+          else {
+            $matches = @(Get-ChildItem "lifecycle-inputs" -Recurse -File -Filter "*setup.exe")
+          }
+          if ($matches.Count -ne 1) {
+            throw "Expected exactly one ${{ matrix.installer_kind }} installer; found $($matches.Count)."
+          }
+          "path=$($matches[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "LIFECYCLE_INPUT kind=${{ matrix.installer_kind }} path=$($matches[0].FullName) size=$($matches[0].Length)"
+
+      - name: Run clean-runner installer lifecycle
+        shell: pwsh
+        run: |
+          & "apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1" `
+            -InstallerKind "${{ matrix.installer_kind }}" `
+            -InstallerPath "${{ steps.installer.outputs.path }}" `
+            -OutputDirectory "lifecycle-evidence/${{ matrix.installer_kind }}" `
+            -SourceCommit "${{ github.event.pull_request.head.sha || github.sha }}"
+
+      - name: Upload lifecycle evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: phoenix-key-${{ matrix.installer_kind }}-lifecycle-evidence
+          path: lifecycle-evidence/${{ matrix.installer_kind }}/
+          if-no-files-found: warn
+          retention-days: 30

--- a/apps/phoenix-key/scripts/emit-artifact-receipt.mjs
+++ b/apps/phoenix-key/scripts/emit-artifact-receipt.mjs
@@ -14,6 +14,8 @@ const packageJson = JSON.parse(readFileSync(resolve(appRoot, "package.json"), "u
 const signatureObservations = JSON.parse(
   readFileSync(join(bundleRoot, "phoenix-key.signature-observation.json"), "utf8")
 );
+const buildWorkflow = process.env.PHOENIX_KEY_BUILD_WORKFLOW ?? "Phoenix Key Desktop";
+const buildCommand = process.env.PHOENIX_KEY_BUILD_COMMAND ?? "npm run desktop:build";
 
 function requireValue(condition, message) {
   if (!condition) {
@@ -26,6 +28,9 @@ function sha256(path) {
 }
 
 requireValue(Array.isArray(signatureObservations), "signature observation root must be an array");
+requireValue(typeof buildWorkflow === "string" && buildWorkflow.trim(), "build workflow identity is required");
+requireValue(typeof buildCommand === "string" && buildCommand.trim(), "build command identity is required");
+
 const signatureByFilename = new Map();
 for (const observation of signatureObservations) {
   requireValue(observation && typeof observation === "object", "signature observation must be an object");
@@ -94,7 +99,7 @@ const receipt = {
     package_formats: ["msi", "nsis"]
   },
   build: {
-    workflow: "Phoenix Key Desktop",
+    workflow: buildWorkflow.trim(),
     workflow_run_id: process.env.GITHUB_RUN_ID ?? "local",
     workflow_run_number: process.env.GITHUB_RUN_NUMBER ?? "local",
     workflow_url: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
@@ -102,7 +107,7 @@ const receipt = {
       : null,
     node: "22",
     rust: "stable",
-    command: "npm run desktop:build",
+    command: buildCommand.trim(),
     boundary_check: "pass",
     compilation: "pass",
     signature_observation: "phoenix-key.signature-observation.json"
@@ -137,6 +142,7 @@ writeFileSync(`${outputPath}.sha256`, `${sha256(outputPath)}  ${basename(outputP
 console.log(JSON.stringify({
   status: "PHOENIX_KEY_ARTIFACT_RECEIPT_WRITTEN",
   output: relative(appRoot, outputPath).replaceAll("\\", "/"),
+  workflow: receipt.build.workflow,
   artifacts: artifacts.map(({ kind, filename, size_bytes, sha256: digest, signature }) => ({
     kind,
     filename,

--- a/apps/phoenix-key/scripts/emit-artifact-receipt.test.mjs
+++ b/apps/phoenix-key/scripts/emit-artifact-receipt.test.mjs
@@ -15,6 +15,8 @@ const msiPath = resolve(fixtureRoot, "msi", "Phoenix Key_3.1.0_x64_en-US.msi");
 const nsisPath = resolve(fixtureRoot, "nsis", "Phoenix Key_3.1.0_x64-setup.exe");
 const observationPath = resolve(fixtureRoot, "phoenix-key.signature-observation.json");
 const commit = "1".repeat(40);
+const workflow = "Phoenix Key Windows Lifecycle";
+const buildCommand = "npm run desktop:build -- lifecycle-input";
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -54,6 +56,8 @@ try {
       ...process.env,
       SOURCE_COMMIT: commit,
       PHOENIX_KEY_BUNDLE_ROOT: fixtureRoot,
+      PHOENIX_KEY_BUILD_WORKFLOW: workflow,
+      PHOENIX_KEY_BUILD_COMMAND: buildCommand,
       GITHUB_RUN_ID: "12345",
       GITHUB_RUN_NUMBER: "9",
       GITHUB_SERVER_URL: "https://github.com",
@@ -64,6 +68,7 @@ try {
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const output = JSON.parse(result.stdout);
   assert.equal(output.status, "PHOENIX_KEY_ARTIFACT_RECEIPT_WRITTEN");
+  assert.equal(output.workflow, workflow);
   assert.equal(output.artifacts.length, 2);
 
   const receiptPath = resolve(fixtureRoot, "phoenix-key.source-artifact.json");
@@ -74,6 +79,8 @@ try {
   assert.equal(receipt.app_id, "phoenix-usb-creator");
   assert.equal(receipt.source.commit, commit);
   assert.equal(receipt.source.version, "3.1.0");
+  assert.equal(receipt.build.workflow, workflow);
+  assert.equal(receipt.build.command, buildCommand);
   assert.equal(receipt.status, "verified-build-output-not-packaged");
   assert.equal(receipt.release_eligible, false);
   assert.equal(receipt.build.signature_observation, "phoenix-key.signature-observation.json");

--- a/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
+++ b/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
@@ -175,7 +175,7 @@ $InstalledExecutable = $null
 $InstalledEntries = @()
 
 try {
-    $PreInstallEntries = Get-PhoenixKeyUninstallEntries
+    $PreInstallEntries = @(Get-PhoenixKeyUninstallEntries)
     if ($PreInstallEntries.Count -ne 0) {
         throw "Runner is not clean: Phoenix Key is already registered before installation."
     }
@@ -197,7 +197,7 @@ try {
     $Installed = $true
 
     Start-Sleep -Seconds 3
-    $InstalledEntries = Get-PhoenixKeyUninstallEntries
+    $InstalledEntries = @(Get-PhoenixKeyUninstallEntries)
     if ($InstalledEntries.Count -lt 1) {
         throw "Phoenix Key did not create an uninstall registration after $InstallerKind installation."
     }
@@ -261,7 +261,7 @@ try {
     $Installed = $false
 
     Start-Sleep -Seconds 4
-    $RemainingEntries = Get-PhoenixKeyUninstallEntries
+    $RemainingEntries = @(Get-PhoenixKeyUninstallEntries)
     $ExecutableRemains = Test-Path -LiteralPath $InstalledExecutable -PathType Leaf
     if ($RemainingEntries.Count -ne 0) {
         throw "Phoenix Key uninstall registration remains after uninstall."
@@ -351,7 +351,7 @@ finally {
                 Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$InstallerPath`" /qn /norestart" -Wait | Out-Null
             }
             else {
-                $CleanupEntries = Get-PhoenixKeyUninstallEntries
+                $CleanupEntries = @(Get-PhoenixKeyUninstallEntries)
                 $CleanupUninstaller = Find-NsisUninstaller -ExecutablePath $InstalledExecutable -UninstallEntries $CleanupEntries
                 Start-Process -FilePath $CleanupUninstaller -ArgumentList "/S" -Wait | Out-Null
             }

--- a/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
+++ b/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
@@ -71,7 +71,10 @@ function Get-PhoenixKeyUninstallEntries {
     $Entries = @()
     foreach ($RegistryPath in $RegistryPaths) {
         $Entries += Get-ItemProperty -Path $RegistryPath -ErrorAction SilentlyContinue |
-            Where-Object { $_.DisplayName -eq $ProductName }
+            Where-Object {
+                $_.PSObject.Properties.Name -contains "DisplayName" -and
+                $_.DisplayName -eq $ProductName
+            }
     }
     return @($Entries)
 }

--- a/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
+++ b/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
@@ -105,7 +105,10 @@ function Find-PhoenixKeyExecutable {
     $Candidates = [System.Collections.Generic.List[string]]::new()
     foreach ($Entry in $UninstallEntries) {
         if ($Entry.PSObject.Properties.Name -contains "InstallLocation") {
-            Add-CandidatePath -Candidates $Candidates -Path (Join-Path ([string]$Entry.InstallLocation) "Phoenix Key.exe")
+            $InstallLocation = [string]$Entry.InstallLocation
+            if (-not [string]::IsNullOrWhiteSpace($InstallLocation)) {
+                Add-CandidatePath -Candidates $Candidates -Path (Join-Path $InstallLocation "Phoenix Key.exe")
+            }
         }
         if ($Entry.PSObject.Properties.Name -contains "DisplayIcon") {
             Add-CandidatePath -Candidates $Candidates -Path ([string]$Entry.DisplayIcon)

--- a/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
+++ b/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
@@ -1,0 +1,357 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("msi", "nsis")]
+    [string]$InstallerKind,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstallerPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-f]{40}$")]
+    [string]$SourceCommit
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$ProductName = "Phoenix Key"
+$AppId = "phoenix-usb-creator"
+$Version = "3.1.0"
+$InstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
+$OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+$InstallLog = Join-Path $OutputDirectory "$InstallerKind-install.log"
+$UninstallLog = Join-Path $OutputDirectory "$InstallerKind-uninstall.log"
+$SmokeReceiptPath = Join-Path $OutputDirectory "$InstallerKind-installed-smoke.json"
+$LifecycleReceiptPath = Join-Path $OutputDirectory "$InstallerKind-lifecycle-receipt.json"
+$FailureReceiptPath = Join-Path $OutputDirectory "$InstallerKind-lifecycle-failure.json"
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Value,
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $Value | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+function Invoke-CheckedProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Arguments,
+        [int[]]$AllowedExitCodes = @(0)
+    )
+
+    Write-Host "PROCESS file=$FilePath arguments=$Arguments"
+    $Process = Start-Process -FilePath $FilePath -ArgumentList $Arguments -Wait -PassThru
+    Write-Host "PROCESS_EXIT file=$FilePath exit_code=$($Process.ExitCode)"
+    if ($AllowedExitCodes -notcontains $Process.ExitCode) {
+        throw "Process failed: $FilePath exited with $($Process.ExitCode); allowed=$($AllowedExitCodes -join ',')"
+    }
+    return $Process.ExitCode
+}
+
+function Get-PhoenixKeyUninstallEntries {
+    $RegistryPaths = @(
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+
+    $Entries = @()
+    foreach ($RegistryPath in $RegistryPaths) {
+        $Entries += Get-ItemProperty -Path $RegistryPath -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -eq $ProductName }
+    }
+    return @($Entries)
+}
+
+function Add-CandidatePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Generic.List[string]]$Candidates,
+        [AllowNull()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+    $Clean = $Path.Trim().Trim('"')
+    if ($Clean -match "^(.*?\.exe)(?:,\d+)?$") {
+        $Clean = $Matches[1]
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Clean) -and -not $Candidates.Contains($Clean)) {
+        $Candidates.Add($Clean)
+    }
+}
+
+function Find-PhoenixKeyExecutable {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$UninstallEntries
+    )
+
+    $Candidates = [System.Collections.Generic.List[string]]::new()
+    foreach ($Entry in $UninstallEntries) {
+        if ($Entry.PSObject.Properties.Name -contains "InstallLocation") {
+            Add-CandidatePath -Candidates $Candidates -Path (Join-Path ([string]$Entry.InstallLocation) "Phoenix Key.exe")
+        }
+        if ($Entry.PSObject.Properties.Name -contains "DisplayIcon") {
+            Add-CandidatePath -Candidates $Candidates -Path ([string]$Entry.DisplayIcon)
+        }
+    }
+
+    if ($env:ProgramFiles) {
+        Add-CandidatePath -Candidates $Candidates -Path (Join-Path $env:ProgramFiles "Phoenix Key\Phoenix Key.exe")
+    }
+    if (${env:ProgramFiles(x86)}) {
+        Add-CandidatePath -Candidates $Candidates -Path (Join-Path ${env:ProgramFiles(x86)} "Phoenix Key\Phoenix Key.exe")
+    }
+    if ($env:LOCALAPPDATA) {
+        Add-CandidatePath -Candidates $Candidates -Path (Join-Path $env:LOCALAPPDATA "Phoenix Key\Phoenix Key.exe")
+    }
+
+    foreach ($Candidate in $Candidates) {
+        if (Test-Path -LiteralPath $Candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $Candidate).Path
+        }
+    }
+
+    throw "Installed Phoenix Key executable was not found. Candidates: $($Candidates -join '; ')"
+}
+
+function Find-NsisUninstaller {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ExecutablePath,
+        [Parameter(Mandatory = $true)]
+        [object[]]$UninstallEntries
+    )
+
+    $LocalCandidate = Join-Path (Split-Path -Parent $ExecutablePath) "uninstall.exe"
+    if (Test-Path -LiteralPath $LocalCandidate -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $LocalCandidate).Path
+    }
+
+    foreach ($Entry in $UninstallEntries) {
+        if ($Entry.PSObject.Properties.Name -contains "UninstallString") {
+            $Raw = [string]$Entry.UninstallString
+            if ($Raw -match '^"([^"]+\.exe)"') {
+                if (Test-Path -LiteralPath $Matches[1] -PathType Leaf) {
+                    return (Resolve-Path -LiteralPath $Matches[1]).Path
+                }
+            }
+            elseif ($Raw -match '^(.*?\.exe)(?:\s|$)') {
+                $Candidate = $Matches[1].Trim('"')
+                if (Test-Path -LiteralPath $Candidate -PathType Leaf) {
+                    return (Resolve-Path -LiteralPath $Candidate).Path
+                }
+            }
+        }
+    }
+
+    throw "NSIS uninstaller was not found."
+}
+
+$Installed = $false
+$InstalledExecutable = $null
+$InstalledEntries = @()
+
+try {
+    $PreInstallEntries = Get-PhoenixKeyUninstallEntries
+    if ($PreInstallEntries.Count -ne 0) {
+        throw "Runner is not clean: Phoenix Key is already registered before installation."
+    }
+
+    $InstallerInfo = Get-Item -LiteralPath $InstallerPath
+    if ($InstallerInfo.Length -le 0) {
+        throw "Installer is empty: $InstallerPath"
+    }
+    $InstallerHash = (Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($InstallerKind -eq "msi") {
+        $InstallArguments = "/i `"$InstallerPath`" /qn /norestart /L*V `"$InstallLog`""
+        $InstallExitCode = Invoke-CheckedProcess -FilePath "msiexec.exe" -Arguments $InstallArguments -AllowedExitCodes @(0, 3010)
+    }
+    else {
+        $InstallExitCode = Invoke-CheckedProcess -FilePath $InstallerPath -Arguments "/S" -AllowedExitCodes @(0)
+        "NSIS silent install exit code: $InstallExitCode" | Set-Content -LiteralPath $InstallLog -Encoding utf8
+    }
+    $Installed = $true
+
+    Start-Sleep -Seconds 3
+    $InstalledEntries = Get-PhoenixKeyUninstallEntries
+    if ($InstalledEntries.Count -lt 1) {
+        throw "Phoenix Key did not create an uninstall registration after $InstallerKind installation."
+    }
+
+    $InstalledExecutable = Find-PhoenixKeyExecutable -UninstallEntries $InstalledEntries
+    $InstalledExecutableHash = (Get-FileHash -LiteralPath $InstalledExecutable -Algorithm SHA256).Hash.ToLowerInvariant()
+    $InstalledExecutableSize = (Get-Item -LiteralPath $InstalledExecutable).Length
+
+    $PreviousSmokeReceipt = $env:PHOENIX_KEY_SMOKE_RECEIPT
+    try {
+        $env:PHOENIX_KEY_SMOKE_RECEIPT = $SmokeReceiptPath
+        $LaunchProcess = Start-Process -FilePath $InstalledExecutable -ArgumentList "--smoke-test" -Wait -PassThru
+    }
+    finally {
+        if ($null -eq $PreviousSmokeReceipt) {
+            Remove-Item Env:\PHOENIX_KEY_SMOKE_RECEIPT -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:PHOENIX_KEY_SMOKE_RECEIPT = $PreviousSmokeReceipt
+        }
+    }
+
+    if ($LaunchProcess.ExitCode -ne 0) {
+        throw "Installed Phoenix Key smoke process exited with $($LaunchProcess.ExitCode)."
+    }
+    if (-not (Test-Path -LiteralPath $SmokeReceiptPath -PathType Leaf)) {
+        throw "Installed Phoenix Key did not emit the expected smoke receipt."
+    }
+
+    $SmokeReceipt = Get-Content -LiteralPath $SmokeReceiptPath -Raw | ConvertFrom-Json
+    if ($SmokeReceipt.schema_version -ne "bws.phoenix-key-installed-smoke/v1") {
+        throw "Unexpected smoke receipt schema: $($SmokeReceipt.schema_version)"
+    }
+    if ($SmokeReceipt.app_id -ne $AppId -or $SmokeReceipt.version -ne $Version) {
+        throw "Installed smoke identity mismatch."
+    }
+    if ($SmokeReceipt.source_commit -ne $SourceCommit) {
+        throw "Installed smoke source commit mismatch: $($SmokeReceipt.source_commit) != $SourceCommit"
+    }
+    if ($SmokeReceipt.status -ne "pass") {
+        throw "Installed smoke receipt did not pass."
+    }
+    if (
+        $SmokeReceipt.safety_boundary.hardware_scan -ne "not-invoked" -or
+        $SmokeReceipt.safety_boundary.media_plan -ne "not-invoked" -or
+        $SmokeReceipt.safety_boundary.physical_write -ne "disabled" -or
+        $SmokeReceipt.safety_boundary.browser_hardware_fabrication -ne "prohibited"
+    ) {
+        throw "Installed smoke receipt crossed the read-only safety boundary."
+    }
+
+    if ($InstallerKind -eq "msi") {
+        $UninstallArguments = "/x `"$InstallerPath`" /qn /norestart /L*V `"$UninstallLog`""
+        $UninstallExitCode = Invoke-CheckedProcess -FilePath "msiexec.exe" -Arguments $UninstallArguments -AllowedExitCodes @(0, 3010)
+    }
+    else {
+        $NsisUninstaller = Find-NsisUninstaller -ExecutablePath $InstalledExecutable -UninstallEntries $InstalledEntries
+        $UninstallExitCode = Invoke-CheckedProcess -FilePath $NsisUninstaller -Arguments "/S" -AllowedExitCodes @(0)
+        "NSIS silent uninstall exit code: $UninstallExitCode" | Set-Content -LiteralPath $UninstallLog -Encoding utf8
+    }
+    $Installed = $false
+
+    Start-Sleep -Seconds 4
+    $RemainingEntries = Get-PhoenixKeyUninstallEntries
+    $ExecutableRemains = Test-Path -LiteralPath $InstalledExecutable -PathType Leaf
+    if ($RemainingEntries.Count -ne 0) {
+        throw "Phoenix Key uninstall registration remains after uninstall."
+    }
+    if ($ExecutableRemains) {
+        throw "Phoenix Key executable remains after uninstall: $InstalledExecutable"
+    }
+
+    $LifecycleReceipt = [ordered]@{
+        schema_version = "bws.app-lifecycle/v1"
+        app_id = $AppId
+        product_name = $ProductName
+        version = $Version
+        source = [ordered]@{
+            repository = "Bboy9090/PhoenixCore-"
+            commit = $SourceCommit
+        }
+        target = [ordered]@{
+            operating_system = "windows"
+            architecture = "x86_64"
+            runner = [System.Environment]::OSVersion.VersionString
+        }
+        installer = [ordered]@{
+            kind = $InstallerKind
+            filename = $InstallerInfo.Name
+            size_bytes = $InstallerInfo.Length
+            sha256 = $InstallerHash
+        }
+        install = [ordered]@{
+            status = "pass"
+            exit_code = $InstallExitCode
+            uninstall_registration_count = $InstalledEntries.Count
+            log = [System.IO.Path]::GetFileName($InstallLog)
+        }
+        launch = [ordered]@{
+            status = "pass"
+            executable_path = $InstalledExecutable
+            executable_size_bytes = $InstalledExecutableSize
+            executable_sha256 = $InstalledExecutableHash
+            process_exit_code = $LaunchProcess.ExitCode
+            smoke_receipt = [System.IO.Path]::GetFileName($SmokeReceiptPath)
+            safety_boundary = $SmokeReceipt.safety_boundary
+        }
+        update = [ordered]@{
+            status = "not-run"
+            reason = "no second released version is available for an update proof"
+        }
+        rollback = [ordered]@{
+            status = "not-run"
+            reason = "no second released version is available for a rollback proof"
+        }
+        uninstall = [ordered]@{
+            status = "pass"
+            exit_code = $UninstallExitCode
+            registration_remaining = $false
+            executable_remaining = $false
+            log = [System.IO.Path]::GetFileName($UninstallLog)
+        }
+        artifact_class = "unsigned-preview-lifecycle-partial"
+        status = "install-launch-uninstall-pass-update-rollback-not-run"
+        release_eligible = $false
+    }
+
+    Write-JsonFile -Value $LifecycleReceipt -Path $LifecycleReceiptPath
+    $ReceiptHash = (Get-FileHash -LiteralPath $LifecycleReceiptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$ReceiptHash  $([System.IO.Path]::GetFileName($LifecycleReceiptPath))" |
+        Set-Content -LiteralPath "$LifecycleReceiptPath.sha256" -Encoding utf8
+
+    Write-Host "PHOENIX_KEY_LIFECYCLE_PASS kind=$InstallerKind receipt=$LifecycleReceiptPath sha256=$ReceiptHash"
+}
+catch {
+    $Failure = [ordered]@{
+        schema_version = "bws.app-lifecycle-failure/v1"
+        app_id = $AppId
+        installer_kind = $InstallerKind
+        source_commit = $SourceCommit
+        error = $_.Exception.Message
+        status = "fail"
+    }
+    Write-JsonFile -Value $Failure -Path $FailureReceiptPath
+    throw
+}
+finally {
+    if ($Installed -and $null -ne $InstalledExecutable) {
+        try {
+            if ($InstallerKind -eq "msi") {
+                Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$InstallerPath`" /qn /norestart" -Wait | Out-Null
+            }
+            else {
+                $CleanupEntries = Get-PhoenixKeyUninstallEntries
+                $CleanupUninstaller = Find-NsisUninstaller -ExecutablePath $InstalledExecutable -UninstallEntries $CleanupEntries
+                Start-Process -FilePath $CleanupUninstaller -ArgumentList "/S" -Wait | Out-Null
+            }
+        }
+        catch {
+            Write-Warning "Best-effort cleanup failed: $($_.Exception.Message)"
+        }
+    }
+}

--- a/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
+++ b/apps/phoenix-key/scripts/test-windows-installer-lifecycle.ps1
@@ -81,7 +81,7 @@ function Get-PhoenixKeyUninstallEntries {
 
 function Add-CandidatePath {
     param(
-        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Collections.Generic.List[string]]$Candidates,
         [AllowNull()]
         [string]$Path
@@ -108,7 +108,7 @@ function Find-PhoenixKeyExecutable {
     $Candidates = [System.Collections.Generic.List[string]]::new()
     foreach ($Entry in $UninstallEntries) {
         if ($Entry.PSObject.Properties.Name -contains "InstallLocation") {
-            $InstallLocation = [string]$Entry.InstallLocation
+            $InstallLocation = ([string]$Entry.InstallLocation).Trim().Trim('"')
             if (-not [string]::IsNullOrWhiteSpace($InstallLocation)) {
                 Add-CandidatePath -Candidates $Candidates -Path (Join-Path $InstallLocation "Phoenix Key.exe")
             }

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -1,11 +1,94 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use libbootforge::{scan_devices, DeviceInfo};
+use serde::Serialize;
 use serde_json::Value;
-use std::{fs, path::PathBuf, process::Command};
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 const USB_CREATOR_SOURCE: &str = include_str!("../../../../usb_creator.py");
 const DEVICE_SCANNER_SOURCE: &str = include_str!("../../../../device_scanner.py");
+const SMOKE_RECEIPT_ENV: &str = "PHOENIX_KEY_SMOKE_RECEIPT";
+
+#[derive(Debug, Serialize)]
+struct SmokeSafetyBoundary {
+    hardware_scan: &'static str,
+    media_plan: &'static str,
+    physical_write: &'static str,
+    browser_hardware_fabrication: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct InstalledSmokeReceipt {
+    schema_version: &'static str,
+    app_id: &'static str,
+    product_name: &'static str,
+    version: &'static str,
+    source_commit: &'static str,
+    target_os: &'static str,
+    target_arch: &'static str,
+    process_id: u32,
+    mode: &'static str,
+    safety_boundary: SmokeSafetyBoundary,
+    status: &'static str,
+}
+
+fn installed_smoke_receipt(process_id: u32) -> InstalledSmokeReceipt {
+    InstalledSmokeReceipt {
+        schema_version: "bws.phoenix-key-installed-smoke/v1",
+        app_id: "phoenix-usb-creator",
+        product_name: "Phoenix Key",
+        version: env!("CARGO_PKG_VERSION"),
+        source_commit: option_env!("PHOENIX_KEY_SOURCE_COMMIT").unwrap_or("unrecorded"),
+        target_os: std::env::consts::OS,
+        target_arch: std::env::consts::ARCH,
+        process_id,
+        mode: "installed-executable-read-only-smoke",
+        safety_boundary: SmokeSafetyBoundary {
+            hardware_scan: "not-invoked",
+            media_plan: "not-invoked",
+            physical_write: "disabled",
+            browser_hardware_fabrication: "prohibited",
+        },
+        status: "pass",
+    }
+}
+
+fn smoke_mode_requested() -> bool {
+    std::env::args_os()
+        .skip(1)
+        .any(|argument| argument == OsStr::new("--smoke-test"))
+}
+
+fn write_installed_smoke_receipt(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("cannot create smoke receipt directory: {error}"))?;
+    }
+
+    let receipt = installed_smoke_receipt(std::process::id());
+    let payload = serde_json::to_vec_pretty(&receipt)
+        .map_err(|error| format!("cannot serialize installed smoke receipt: {error}"))?;
+    fs::write(path, payload).map_err(|error| format!("cannot write installed smoke receipt: {error}"))
+}
+
+fn run_smoke_mode_if_requested() -> Result<bool, String> {
+    if !smoke_mode_requested() {
+        return Ok(false);
+    }
+
+    let receipt_path = std::env::var_os(SMOKE_RECEIPT_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("{SMOKE_RECEIPT_ENV} is required for --smoke-test"))?;
+
+    write_installed_smoke_receipt(&receipt_path)?;
+    Ok(true)
+}
 
 #[tauri::command]
 fn scan_connected_devices() -> Result<Vec<DeviceInfo>, String> {
@@ -14,37 +97,59 @@ fn scan_connected_devices() -> Result<Vec<DeviceInfo>, String> {
 
 fn bridge_directory() -> Result<PathBuf, String> {
     let directory = std::env::temp_dir().join(format!("phoenix-key-{}", std::process::id()));
-    fs::create_dir_all(&directory).map_err(|error| format!("cannot create PhoenixCore bridge directory: {error}"))?;
-    fs::write(directory.join("usb_creator.py"), USB_CREATOR_SOURCE).map_err(|error| format!("cannot stage embedded USB creator: {error}"))?;
-    fs::write(directory.join("device_scanner.py"), DEVICE_SCANNER_SOURCE).map_err(|error| format!("cannot stage embedded device scanner: {error}"))?;
+    fs::create_dir_all(&directory)
+        .map_err(|error| format!("cannot create PhoenixCore bridge directory: {error}"))?;
+    fs::write(directory.join("usb_creator.py"), USB_CREATOR_SOURCE)
+        .map_err(|error| format!("cannot stage embedded USB creator: {error}"))?;
+    fs::write(directory.join("device_scanner.py"), DEVICE_SCANNER_SOURCE)
+        .map_err(|error| format!("cannot stage embedded device scanner: {error}"))?;
     Ok(directory)
 }
 
 fn run_phoenixcore(args: &[&str]) -> Result<Value, String> {
     let directory = bridge_directory()?;
     let script = directory.join("usb_creator.py");
-    let candidates: &[&str] = if cfg!(windows) { &["python", "py"] } else { &["python3", "python"] };
+    let candidates: &[&str] = if cfg!(windows) {
+        &["python", "py"]
+    } else {
+        &["python3", "python"]
+    };
     let mut failures = Vec::new();
 
     for candidate in candidates {
         let mut command = Command::new(candidate);
-        if *candidate == "py" { command.arg("-3"); }
-        let result = command.arg(&script).args(args).current_dir(&directory).output();
+        if *candidate == "py" {
+            command.arg("-3");
+        }
+        let result = command
+            .arg(&script)
+            .args(args)
+            .current_dir(&directory)
+            .output();
         match result {
             Ok(output) if output.status.success() => {
                 let parsed = serde_json::from_slice::<Value>(&output.stdout).map_err(|error| {
-                    format!("PhoenixCore returned invalid JSON: {error}; stdout={}", String::from_utf8_lossy(&output.stdout))
+                    format!(
+                        "PhoenixCore returned invalid JSON: {error}; stdout={}",
+                        String::from_utf8_lossy(&output.stdout)
+                    )
                 });
                 let _ = fs::remove_dir_all(&directory);
                 return parsed;
             }
-            Ok(output) => failures.push(format!("{candidate}: {}", String::from_utf8_lossy(&output.stderr).trim())),
+            Ok(output) => failures.push(format!(
+                "{candidate}: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
             Err(error) => failures.push(format!("{candidate}: {error}")),
         }
     }
 
     let _ = fs::remove_dir_all(&directory);
-    Err(format!("PhoenixCore Python bridge unavailable: {}", failures.join(" | ")))
+    Err(format!(
+        "PhoenixCore Python bridge unavailable: {}",
+        failures.join(" | ")
+    ))
 }
 
 #[tauri::command]
@@ -57,12 +162,51 @@ fn plan_media_build(target_drive: String, image_path: String) -> Result<Value, S
     if target_drive.trim().is_empty() || image_path.trim().is_empty() {
         return Err("target drive and image path are required".to_string());
     }
-    run_phoenixcore(&["--plan-write", "--target-drive", &target_drive, "--image", &image_path])
+    run_phoenixcore(&[
+        "--plan-write",
+        "--target-drive",
+        &target_drive,
+        "--image",
+        &image_path,
+    ])
 }
 
 fn main() {
+    match run_smoke_mode_if_requested() {
+        Ok(true) => return,
+        Ok(false) => {}
+        Err(_) => std::process::exit(70),
+    }
+
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![scan_connected_devices, scan_media_targets, plan_media_build])
+        .invoke_handler(tauri::generate_handler![
+            scan_connected_devices,
+            scan_media_targets,
+            plan_media_build
+        ])
         .run(tauri::generate_context!())
         .expect("failed to run Phoenix Key desktop application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::installed_smoke_receipt;
+
+    #[test]
+    fn installed_smoke_receipt_is_read_only_and_non_destructive() {
+        let receipt = installed_smoke_receipt(42);
+        let value = serde_json::to_value(receipt).expect("smoke receipt should serialize");
+
+        assert_eq!(value["schema_version"], "bws.phoenix-key-installed-smoke/v1");
+        assert_eq!(value["app_id"], "phoenix-usb-creator");
+        assert_eq!(value["process_id"], 42);
+        assert_eq!(value["status"], "pass");
+        assert_eq!(value["safety_boundary"]["hardware_scan"], "not-invoked");
+        assert_eq!(value["safety_boundary"]["media_plan"], "not-invoked");
+        assert_eq!(value["safety_boundary"]["physical_write"], "disabled");
+        assert_eq!(
+            value["safety_boundary"]["browser_hardware_fabrication"],
+            "prohibited"
+        );
+    }
 }


### PR DESCRIPTION
## Purpose

Add the first real Windows lifecycle receipts for Phoenix Key installers after producer PR #130 establishes deterministic build receipts.

This PR is stacked on `agent/phoenix-key-artifact-receipts-v1` and does not merge or modify `main` directly.

## Implemented

- installed-executable `--smoke-test` mode
- versioned `bws.phoenix-key-installed-smoke/v1` receipt
- compile-time source commit identity
- smoke mode exits before Tauri startup
- hardware scan, media planning, and physical write remain uninvoked/disabled
- Rust unit test for the smoke receipt safety boundary
- same-build source artifact receipt and unsigned-signature observations
- one Windows installer build shared by lifecycle jobs
- separate clean Windows runners for MSI and NSIS
- silent install, installed launch, silent uninstall, and cleanup verification
- installed executable path, size, and SHA-256 capture
- versioned `bws.app-lifecycle/v1` receipts and checksums
- source-to-installer-to-lifecycle linkage validation
- failure receipts, best-effort cleanup, concurrency cancellation, and Rust caching

## Canonical same-commit validation

Source head:

```text
f68c2cb917ec1d800956232de7ea99e60cdb94f7
```

Workflow:

```text
Phoenix Key Windows Lifecycle
run_id: 30042136932
run_number: 9
result: PASS
```

All jobs passed:

- source artifact receipt generator test
- installed smoke receipt Rust test
- MSI and NSIS build
- unsigned Authenticode observation
- same-commit source receipt generation
- MSI clean-runner lifecycle
- NSIS clean-runner lifecycle

## Same-build source artifact evidence

Retained artifact:

```text
artifact_id: 8577704770
name: phoenix-key-windows-lifecycle-inputs
archive_size: 2,951,947 bytes
archive_sha256: 519023bb0db192c3237cf00ddb740c5ac059c38e41778b0fcb7854e396b86726
expires: 2026-08-22
```

Source receipt:

```text
schema: bws.source-app-artifact/v1
source_commit: f68c2cb917ec1d800956232de7ea99e60cdb94f7
workflow: Phoenix Key Windows Lifecycle
receipt_sha256: 6fd65f06ef4cef46b1c272cbf32c1b104fb7a48d50aad2e3c6c1a395ca0e22d0
checksum verification: PASS
```

Both installers report `NotSigned`, with no signer or timestamp certificate.

## MSI lifecycle evidence

```text
artifact_id: 8577720087
archive_size: 24,009 bytes
archive_sha256: 44793dc45d3af107cdfe7a5a366b12c119904147b0de759b418a88a53feecae2
expires: 2026-08-22
```

| Field | Value |
|---|---|
| Installer | `Phoenix Key_3.1.0_x64_en-US.msi` |
| Installer size | 1,974,272 bytes |
| Installer SHA-256 | `24b87ad13d8fb7426ef8653e7ce31c1a27195b57c296e884327895910d0496ae` |
| Install exit | 0 |
| Installed path | `C:\Program Files\Phoenix Key\Phoenix Key.exe` |
| Installed executable size | 4,324,352 bytes |
| Installed executable SHA-256 | `0430360d981ff055787590c58d438c9dbb1948acfba4e0aa606e4e5df5f36176` |
| Launch exit | 0 |
| Uninstall exit | 0 |
| Registration remaining | false |
| Executable remaining | false |

## NSIS lifecycle evidence

```text
artifact_id: 8577717699
archive_size: 2,018 bytes
archive_sha256: 7c2768b1b21918fab39d0668f3f5b9775ecba5abc3ced91046af2e0bb0a4360c
expires: 2026-08-22
```

| Field | Value |
|---|---|
| Installer | `Phoenix Key_3.1.0_x64-setup.exe` |
| Installer size | 1,275,255 bytes |
| Installer SHA-256 | `cd3f3070c58557b4039f5c7c3aad7e1630025c2746a6eb793a91fa5b1c9dda57` |
| Install exit | 0 |
| Installed path | `C:\Users\runneradmin\AppData\Local\Phoenix Key\Phoenix Key.exe` |
| Installed executable size | 4,324,352 bytes |
| Installed executable SHA-256 | `0430360d981ff055787590c58d438c9dbb1948acfba4e0aa606e4e5df5f36176` |
| Launch exit | 0 |
| Uninstall exit | 0 |
| Registration remaining | false |
| Executable remaining | false |

The source receipt installer hashes exactly match both lifecycle receipts. MSI and NSIS install the same executable payload hash.

## Installed smoke safety proof

Both installed applications emitted:

```text
schema_version: bws.phoenix-key-installed-smoke/v1
app_id: phoenix-usb-creator
version: 3.1.0
source_commit: f68c2cb917ec1d800956232de7ea99e60cdb94f7
hardware_scan: not-invoked
media_plan: not-invoked
physical_write: disabled
browser_hardware_fabrication: prohibited
status: pass
```

## Proven classification

```text
source build: verified unsigned preview
install: pass
launch: pass
uninstall: pass
update: not-run
rollback: not-run
artifact_class: unsigned-preview-lifecycle-partial
release_eligible: false
```

Update and rollback require a second version and declared rollback mechanism. Signing, signature verification, ARCWYRE embedding, and release promotion remain separate gates.

## Dependency

- Producer PR #130 must land first.
- Issue #132 remains open for update, rollback, signing, and final promotion.
- Native packaging may consume this linked partial lifecycle evidence while retaining the release blocker.
