### PR TITLE
Phase 5B-4: Windows PHYSICALDRIVE target resolution fix

### DIFF
--- a/.github/workflows/phoenix-key-desktop.yml
+++ b/.github/workflows/phoenix-key-desktop.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - run: npm ci
+      - name: Run Phoenix Key Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
       - name: Build Phoenix Key installers
         run: npm run desktop:build
       - name: Upload unsigned preview installers

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -93,8 +93,8 @@ fn attach_target_resolution(
     object.insert(
         "target_resolution".to_string(),
         json!({
-            "requested_path": resolution.requested_path,
-            "canonical_path": resolution.canonical_path,
+            "requested_path": &resolution.requested_path,
+            "canonical_path": &resolution.canonical_path,
             "resolution_source": resolution.resolution_source,
             "target_kind": resolution.target_kind,
             "canonicalized": resolution.canonicalized,

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ use windows_target::{resolve_target, TargetResolution};
 
 const USB_CREATOR_SOURCE: &str = include_str!("../../../../usb_creator.py");
 const DEVICE_SCANNER_SOURCE: &str = include_str!("../../../../device_scanner.py");
+const TARGET_RESOLUTION_SCHEMA: &str = "phoenix_key.target_resolution.v1";
 
 #[tauri::command]
 fn scan_connected_devices() -> Result<Vec<DeviceInfo>, String> {
@@ -86,6 +87,16 @@ fn attach_target_resolution(
         true
     };
 
+    let resolution_status = if resolution.is_windows_physical_drive() {
+        if scanner_planner_consistent {
+            "target_resolved_from_scanner_evidence"
+        } else {
+            "target_not_resolved_from_scanner_evidence"
+        }
+    } else {
+        "target_passthrough"
+    };
+
     let object = plan
         .as_object_mut()
         .ok_or_else(|| "phoenixcore_plan_not_json_object".to_string())?;
@@ -93,9 +104,11 @@ fn attach_target_resolution(
     object.insert(
         "target_resolution".to_string(),
         json!({
+            "schema": TARGET_RESOLUTION_SCHEMA,
             "requested_path": &resolution.requested_path,
             "canonical_path": &resolution.canonical_path,
             "resolution_source": resolution.resolution_source,
+            "resolution_status": resolution_status,
             "target_kind": resolution.target_kind,
             "canonicalized": resolution.canonicalized,
             "planner_root": planner_root,
@@ -161,9 +174,19 @@ mod tests {
         attach_target_resolution(&mut plan, &resolution).unwrap();
 
         assert_eq!(
+            plan.pointer("/target_resolution/schema")
+                .and_then(|value| value.as_str()),
+            Some("phoenix_key.target_resolution.v1")
+        );
+        assert_eq!(
             plan.pointer("/target_resolution/canonical_path")
                 .and_then(|value| value.as_str()),
             Some(r"\\.\PHYSICALDRIVE1")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_resolved_from_scanner_evidence")
         );
         assert_eq!(
             plan.pointer("/target_resolution/scanner_planner_consistent")
@@ -183,6 +206,11 @@ mod tests {
         attach_target_resolution(&mut plan, &resolution).unwrap();
 
         assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_not_resolved_from_scanner_evidence")
+        );
+        assert_eq!(
             plan.pointer("/target_resolution/scanner_planner_consistent")
                 .and_then(|value| value.as_bool()),
             Some(false)
@@ -190,6 +218,31 @@ mod tests {
         assert!(plan
             .pointer("/target_resolution/planner_root")
             .is_some_and(|value| value.is_null()));
+    }
+
+    #[test]
+    fn records_passthrough_target_status() {
+        let resolution = resolve_target("E:\\").unwrap();
+        let mut plan = json!({
+            "drive_safety": {
+                "drive": {
+                    "root": "E:\\"
+                }
+            }
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
+        assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_passthrough")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
     }
 
     #[test]

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -1,8 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod windows_target;
+
 use libbootforge::{scan_devices, DeviceInfo};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{fs, path::PathBuf, process::Command};
+use windows_target::{resolve_target, TargetResolution};
 
 const USB_CREATOR_SOURCE: &str = include_str!("../../../../usb_creator.py");
 const DEVICE_SCANNER_SOURCE: &str = include_str!("../../../../device_scanner.py");
@@ -65,24 +68,42 @@ fn run_phoenixcore(args: &[&str]) -> Result<Value, String> {
     ))
 }
 
-fn canonicalize_windows_physical_drive_arg(value: &str) -> String {
-    let trimmed = value.trim().replace('/', "\\");
-    let upper = trimmed.to_ascii_uppercase();
-    let marker = "PHYSICALDRIVE";
+fn attach_target_resolution(
+    plan: &mut Value,
+    resolution: &TargetResolution,
+) -> Result<(), String> {
+    let planner_root = plan
+        .pointer("/drive_safety/drive/root")
+        .and_then(Value::as_str)
+        .map(str::to_string);
 
-    if let Some(index) = upper.find(marker) {
-        let suffix = &upper[index + marker.len()..];
-        let digits: String = suffix
-            .chars()
-            .take_while(|character| character.is_ascii_digit())
-            .collect();
+    let scanner_planner_consistent = if resolution.is_windows_physical_drive() {
+        planner_root
+            .as_deref()
+            .map(|root| root.eq_ignore_ascii_case(&resolution.canonical_path))
+            .unwrap_or(false)
+    } else {
+        true
+    };
 
-        if !digits.is_empty() {
-            return format!("\\\\.\\PHYSICALDRIVE{digits}");
-        }
-    }
+    let object = plan
+        .as_object_mut()
+        .ok_or_else(|| "phoenixcore_plan_not_json_object".to_string())?;
 
-    trimmed
+    object.insert(
+        "target_resolution".to_string(),
+        json!({
+            "requested_path": resolution.requested_path,
+            "canonical_path": resolution.canonical_path,
+            "resolution_source": resolution.resolution_source,
+            "target_kind": resolution.target_kind,
+            "canonicalized": resolution.canonicalized,
+            "planner_root": planner_root,
+            "scanner_planner_consistent": scanner_planner_consistent,
+        }),
+    );
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -96,16 +117,18 @@ fn plan_media_build(target_drive: String, image_path: String) -> Result<Value, S
         return Err("target drive and image path are required".to_string());
     }
 
-    let normalized_target = canonicalize_windows_physical_drive_arg(&target_drive);
+    let target_resolution = resolve_target(&target_drive)?;
     let normalized_image = image_path.trim().to_string();
 
-    run_phoenixcore(&[
+    let mut plan = run_phoenixcore(&[
         "--plan-write",
         "--target-drive",
-        &normalized_target,
+        &target_resolution.canonical_path,
         "--image",
         &normalized_image,
-    ])
+    ])?;
+    attach_target_resolution(&mut plan, &target_resolution)?;
+    Ok(plan)
 }
 
 fn main() {
@@ -121,42 +144,60 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::canonicalize_windows_physical_drive_arg;
+    use super::{attach_target_resolution, resolve_target};
+    use serde_json::json;
 
     #[test]
-    fn canonicalizes_standard_windows_physical_drive() {
+    fn records_consistent_scanner_planner_resolution() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!({
+            "drive_safety": {
+                "drive": {
+                    "root": "\\\\.\\PHYSICALDRIVE1"
+                }
+            }
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
         assert_eq!(
-            canonicalize_windows_physical_drive_arg(r"\\.\PHYSICALDRIVE1"),
-            r"\\.\PHYSICALDRIVE1"
+            plan.pointer("/target_resolution/canonical_path")
+                .and_then(|value| value.as_str()),
+            Some(r"\\.\PHYSICALDRIVE1")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(true)
         );
     }
 
     #[test]
-    fn canonicalizes_plain_physical_drive() {
+    fn records_missing_planner_root_as_inconsistent() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!({
+            "blocked": true,
+            "block_reasons": ["target_not_found_in_scan_evidence"]
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
         assert_eq!(
-            canonicalize_windows_physical_drive_arg("PHYSICALDRIVE1"),
-            r"\\.\PHYSICALDRIVE1"
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(false)
         );
+        assert!(plan
+            .pointer("/target_resolution/planner_root")
+            .is_some_and(|value| value.is_null()));
     }
 
     #[test]
-    fn canonicalizes_lowercase_physical_drive() {
-        assert_eq!(
-            canonicalize_windows_physical_drive_arg("physicaldrive1"),
-            r"\\.\PHYSICALDRIVE1"
-        );
-    }
+    fn rejects_non_object_plan_payload() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!(["unexpected"]);
 
-    #[test]
-    fn canonicalizes_over_escaped_physical_drive() {
-        assert_eq!(
-            canonicalize_windows_physical_drive_arg(r"\\\\.\\PHYSICALDRIVE1"),
-            r"\\.\PHYSICALDRIVE1"
-        );
-    }
-
-    #[test]
-    fn leaves_non_physical_drive_target_unchanged() {
-        assert_eq!(canonicalize_windows_physical_drive_arg("E:\\"), "E:\\");
+        let error = attach_target_resolution(&mut plan, &resolution).unwrap_err();
+        assert_eq!(error, "phoenixcore_plan_not_json_object");
     }
 }

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -14,37 +14,75 @@ fn scan_connected_devices() -> Result<Vec<DeviceInfo>, String> {
 
 fn bridge_directory() -> Result<PathBuf, String> {
     let directory = std::env::temp_dir().join(format!("phoenix-key-{}", std::process::id()));
-    fs::create_dir_all(&directory).map_err(|error| format!("cannot create PhoenixCore bridge directory: {error}"))?;
-    fs::write(directory.join("usb_creator.py"), USB_CREATOR_SOURCE).map_err(|error| format!("cannot stage embedded USB creator: {error}"))?;
-    fs::write(directory.join("device_scanner.py"), DEVICE_SCANNER_SOURCE).map_err(|error| format!("cannot stage embedded device scanner: {error}"))?;
+    fs::create_dir_all(&directory)
+        .map_err(|error| format!("cannot create PhoenixCore bridge directory: {error}"))?;
+    fs::write(directory.join("usb_creator.py"), USB_CREATOR_SOURCE)
+        .map_err(|error| format!("cannot stage embedded USB creator: {error}"))?;
+    fs::write(directory.join("device_scanner.py"), DEVICE_SCANNER_SOURCE)
+        .map_err(|error| format!("cannot stage embedded device scanner: {error}"))?;
     Ok(directory)
 }
 
 fn run_phoenixcore(args: &[&str]) -> Result<Value, String> {
     let directory = bridge_directory()?;
     let script = directory.join("usb_creator.py");
-    let candidates: &[&str] = if cfg!(windows) { &["python", "py"] } else { &["python3", "python"] };
+    let candidates: &[&str] = if cfg!(windows) {
+        &["python", "py"]
+    } else {
+        &["python3", "python"]
+    };
     let mut failures = Vec::new();
 
     for candidate in candidates {
         let mut command = Command::new(candidate);
-        if *candidate == "py" { command.arg("-3"); }
+        if *candidate == "py" {
+            command.arg("-3");
+        }
         let result = command.arg(&script).args(args).current_dir(&directory).output();
         match result {
             Ok(output) if output.status.success() => {
                 let parsed = serde_json::from_slice::<Value>(&output.stdout).map_err(|error| {
-                    format!("PhoenixCore returned invalid JSON: {error}; stdout={}", String::from_utf8_lossy(&output.stdout))
+                    format!(
+                        "PhoenixCore returned invalid JSON: {error}; stdout={}",
+                        String::from_utf8_lossy(&output.stdout)
+                    )
                 });
                 let _ = fs::remove_dir_all(&directory);
                 return parsed;
             }
-            Ok(output) => failures.push(format!("{candidate}: {}", String::from_utf8_lossy(&output.stderr).trim())),
+            Ok(output) => failures.push(format!(
+                "{candidate}: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
             Err(error) => failures.push(format!("{candidate}: {error}")),
         }
     }
 
     let _ = fs::remove_dir_all(&directory);
-    Err(format!("PhoenixCore Python bridge unavailable: {}", failures.join(" | ")))
+    Err(format!(
+        "PhoenixCore Python bridge unavailable: {}",
+        failures.join(" | ")
+    ))
+}
+
+fn canonicalize_windows_physical_drive_arg(value: &str) -> String {
+    let trimmed = value.trim().replace('/', "\\");
+    let upper = trimmed.to_ascii_uppercase();
+    let marker = "PHYSICALDRIVE";
+
+    if let Some(index) = upper.find(marker) {
+        let suffix = &upper[index + marker.len()..];
+        let digits: String = suffix
+            .chars()
+            .take_while(|character| character.is_ascii_digit())
+            .collect();
+
+        if !digits.is_empty() {
+            return format!("\\\\.\\PHYSICALDRIVE{digits}");
+        }
+    }
+
+    trimmed
 }
 
 #[tauri::command]
@@ -57,12 +95,68 @@ fn plan_media_build(target_drive: String, image_path: String) -> Result<Value, S
     if target_drive.trim().is_empty() || image_path.trim().is_empty() {
         return Err("target drive and image path are required".to_string());
     }
-    run_phoenixcore(&["--plan-write", "--target-drive", &target_drive, "--image", &image_path])
+
+    let normalized_target = canonicalize_windows_physical_drive_arg(&target_drive);
+    let normalized_image = image_path.trim().to_string();
+
+    run_phoenixcore(&[
+        "--plan-write",
+        "--target-drive",
+        &normalized_target,
+        "--image",
+        &normalized_image,
+    ])
 }
 
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![scan_connected_devices, scan_media_targets, plan_media_build])
+        .invoke_handler(tauri::generate_handler![
+            scan_connected_devices,
+            scan_media_targets,
+            plan_media_build
+        ])
         .run(tauri::generate_context!())
         .expect("failed to run Phoenix Key desktop application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonicalize_windows_physical_drive_arg;
+
+    #[test]
+    fn canonicalizes_standard_windows_physical_drive() {
+        assert_eq!(
+            canonicalize_windows_physical_drive_arg(r"\\.\PHYSICALDRIVE1"),
+            r"\\.\PHYSICALDRIVE1"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_plain_physical_drive() {
+        assert_eq!(
+            canonicalize_windows_physical_drive_arg("PHYSICALDRIVE1"),
+            r"\\.\PHYSICALDRIVE1"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_lowercase_physical_drive() {
+        assert_eq!(
+            canonicalize_windows_physical_drive_arg("physicaldrive1"),
+            r"\\.\PHYSICALDRIVE1"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_over_escaped_physical_drive() {
+        assert_eq!(
+            canonicalize_windows_physical_drive_arg(r"\\\\.\\PHYSICALDRIVE1"),
+            r"\\.\PHYSICALDRIVE1"
+        );
+    }
+
+    #[test]
+    fn leaves_non_physical_drive_target_unchanged() {
+        assert_eq!(canonicalize_windows_physical_drive_arg("E:\\"), "E:\\");
+    }
 }

--- a/apps/phoenix-key/src-tauri/src/windows_target.rs
+++ b/apps/phoenix-key/src-tauri/src/windows_target.rs
@@ -1,0 +1,138 @@
+use serde::Serialize;
+
+const PHYSICAL_DRIVE_MARKER: &str = "PHYSICALDRIVE";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetResolution {
+    pub requested_path: String,
+    pub canonical_path: String,
+    pub resolution_source: &'static str,
+    pub target_kind: &'static str,
+    pub canonicalized: bool,
+}
+
+impl TargetResolution {
+    pub fn is_windows_physical_drive(&self) -> bool {
+        self.target_kind == "windows_physical_drive"
+    }
+}
+
+pub fn resolve_target(value: &str) -> Result<TargetResolution, String> {
+    let requested_path = value.trim().replace('/', "\\");
+    if requested_path.is_empty() {
+        return Err("target_drive_empty".to_string());
+    }
+
+    let upper = requested_path.to_ascii_uppercase();
+    let Some(marker_index) = upper.find(PHYSICAL_DRIVE_MARKER) else {
+        return Ok(TargetResolution {
+            canonical_path: requested_path.clone(),
+            requested_path,
+            resolution_source: "phoenix_key_bridge_passthrough",
+            target_kind: "filesystem_or_volume_path",
+            canonicalized: false,
+        });
+    };
+
+    let prefix = &upper[..marker_index];
+    let suffix = &upper[marker_index + PHYSICAL_DRIVE_MARKER.len()..];
+    let prefix_without_slashes: String = prefix
+        .chars()
+        .filter(|character| *character != '\\')
+        .collect();
+
+    if !(prefix_without_slashes.is_empty() || prefix_without_slashes == ".") {
+        return Err("invalid_windows_physicaldrive_prefix".to_string());
+    }
+
+    if suffix.is_empty() || !suffix.chars().all(|character| character.is_ascii_digit()) {
+        return Err("invalid_windows_physicaldrive_suffix".to_string());
+    }
+
+    let disk_number = suffix
+        .parse::<u32>()
+        .map_err(|_| "invalid_windows_physicaldrive_number".to_string())?;
+    let canonical_path = format!(r"\\.\PHYSICALDRIVE{disk_number}");
+    let canonicalized = requested_path != canonical_path;
+
+    Ok(TargetResolution {
+        requested_path,
+        canonical_path,
+        resolution_source: "phoenix_key_bridge",
+        target_kind: "windows_physical_drive",
+        canonicalized,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_target;
+
+    #[test]
+    fn canonicalizes_standard_windows_physical_drive() {
+        let resolution = resolve_target(r"\\.\PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(!resolution.canonicalized);
+        assert!(resolution.is_windows_physical_drive());
+    }
+
+    #[test]
+    fn canonicalizes_plain_physical_drive() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_lowercase_physical_drive() {
+        let resolution = resolve_target("physicaldrive1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_over_escaped_physical_drive() {
+        let resolution = resolve_target(r"\\\\.\\PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_forward_slash_physical_drive() {
+        let resolution = resolve_target("//./physicaldrive1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn removes_leading_zeroes_from_disk_number() {
+        let resolution = resolve_target("PHYSICALDRIVE001").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+    }
+
+    #[test]
+    fn leaves_non_physical_drive_target_unchanged() {
+        let resolution = resolve_target("E:\\").unwrap();
+        assert_eq!(resolution.canonical_path, "E:\\");
+        assert!(!resolution.canonicalized);
+        assert!(!resolution.is_windows_physical_drive());
+    }
+
+    #[test]
+    fn rejects_embedded_physical_drive_marker() {
+        let error = resolve_target(r"C:\temp\PHYSICALDRIVE1").unwrap_err();
+        assert_eq!(error, "invalid_windows_physicaldrive_prefix");
+    }
+
+    #[test]
+    fn rejects_trailing_physical_drive_junk() {
+        let error = resolve_target("PHYSICALDRIVE1.tmp").unwrap_err();
+        assert_eq!(error, "invalid_windows_physicaldrive_suffix");
+    }
+
+    #[test]
+    fn rejects_empty_target() {
+        let error = resolve_target("   ").unwrap_err();
+        assert_eq!(error, "target_drive_empty");
+    }
+}

--- a/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+++ b/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
@@ -93,6 +93,7 @@ If PhoenixCore does not return a matching planner root, the plan remains visible
 ## Files changed
 
 ```text
+.github/workflows/phoenix-key-desktop.yml
 apps/phoenix-key/src-tauri/src/main.rs
 apps/phoenix-key/src-tauri/src/windows_target.rs
 docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
@@ -143,6 +144,14 @@ records_consistent_scanner_planner_resolution
 records_missing_planner_root_as_inconsistent
 rejects_non_object_plan_payload
 ```
+
+The Phoenix Key Windows workflow now runs:
+
+```text
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+before building MSI and NSIS preview installers. A failed Rust unit test blocks installer packaging and artifact upload.
 
 ## Required verification before merge
 

--- a/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+++ b/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation started on branch `fix/windows-physicaldrive-target-resolution`.
+Implementation is active on branch `fix/windows-physicaldrive-target-resolution` in draft PR #143.
 
 This lane is a focused blocker fix for PR #123 hardware-test evidence. It does not authorize marking PR #123 ready, merging `main`, adding physical-write controls, or changing the BootForge USB repository.
 
@@ -26,35 +26,81 @@ actual_write_enabled: false
 
 ## Fix summary
 
-Phoenix Key now canonicalizes Windows physical-drive target arguments at the desktop bridge boundary before invoking the embedded PhoenixCore dry-run planner.
+Phoenix Key now resolves Windows physical-drive target arguments through a dedicated typed resolver before invoking the embedded PhoenixCore dry-run planner.
 
-The bridge normalizes these equivalent target spellings:
+The resolver accepts these equivalent target spellings:
 
 ```text
 \\.\PHYSICALDRIVE1
 PHYSICALDRIVE1
 physicaldrive1
 \\\\.\\PHYSICALDRIVE1
+//./physicaldrive1
 ```
 
-into the canonical planner argument:
+and emits the canonical planner argument:
 
 ```text
 \\.\PHYSICALDRIVE1
 ```
 
-This prevents an over-escaped scanner value from bypassing the existing Python scanner-evidence path and falling into ordinary filesystem path validation.
+The resolver also:
+
+- removes leading zeroes from a disk number, such as `PHYSICALDRIVE001` to `\\.\PHYSICALDRIVE1`
+- rejects embedded markers such as `C:\temp\PHYSICALDRIVE1`
+- rejects trailing junk such as `PHYSICALDRIVE1.tmp`
+- rejects an empty target
+- passes ordinary drive-letter or filesystem targets through unchanged
+
+This prevents over-escaped or non-canonical scanner values from bypassing the existing Python scanner-evidence path and falling into ordinary filesystem path validation.
+
+## Integration behavior
+
+`plan_media_build` now:
+
+1. resolves the selected target through `windows_target::resolve_target`
+2. passes the canonical target to the embedded PhoenixCore `--plan-write` command
+3. records target-resolution evidence in the returned JSON plan
+
+The added `target_resolution` object contains:
+
+```text
+requested_path
+canonical_path
+resolution_source
+target_kind
+canonicalized
+planner_root
+scanner_planner_consistent
+```
+
+For the receipt scenario, expected evidence is:
+
+```json
+{
+  "requested_path": "PHYSICALDRIVE1",
+  "canonical_path": "\\\\.\\PHYSICALDRIVE1",
+  "resolution_source": "phoenix_key_bridge",
+  "target_kind": "windows_physical_drive",
+  "canonicalized": true,
+  "planner_root": "\\\\.\\PHYSICALDRIVE1",
+  "scanner_planner_consistent": true
+}
+```
+
+If PhoenixCore does not return a matching planner root, the plan remains visible but `scanner_planner_consistent` is recorded as `false`. The bridge does not guess, substitute a different disk, or enable writing.
 
 ## Files changed
 
 ```text
 apps/phoenix-key/src-tauri/src/main.rs
+apps/phoenix-key/src-tauri/src/windows_target.rs
 docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
 ```
 
 ## Safety boundary
 
-This fix only normalizes a target identifier before dry-run planning.
+This fix only resolves and records a target identifier before dry-run planning.
 
 It does not add:
 
@@ -69,16 +115,33 @@ dashboard write controls
 consumer write mode
 ```
 
+Existing safety claims remain:
+
+```text
+actual_write_enabled: false
+physical_write_attempted: false
+bytes_written: 0
+dashboard write path: absent
+```
+
 ## Added validation
 
-Rust unit coverage was added for Phoenix Key bridge normalization:
+Rust unit coverage now includes:
 
 ```text
 canonicalizes_standard_windows_physical_drive
 canonicalizes_plain_physical_drive
 canonicalizes_lowercase_physical_drive
 canonicalizes_over_escaped_physical_drive
+canonicalizes_forward_slash_physical_drive
+removes_leading_zeroes_from_disk_number
 leaves_non_physical_drive_target_unchanged
+rejects_embedded_physical_drive_marker
+rejects_trailing_physical_drive_junk
+rejects_empty_target
+records_consistent_scanner_planner_resolution
+records_missing_planner_root_as_inconsistent
+rejects_non_object_plan_payload
 ```
 
 ## Required verification before merge
@@ -119,17 +182,18 @@ PR #123 remains draft
 
 ## Required hardware retest
 
-After CI passes, run a replacement Windows hardware receipt using the unsigned Phoenix Key preview installer built from this fix branch.
+After CI passes, run a replacement Windows hardware receipt using the unsigned Phoenix Key preview installer built from PR #143.
 
 The replacement receipt must prove:
 
 ```text
 scanner target: \\.\PHYSICALDRIVE1
 planner target: \\.\PHYSICALDRIVE1
+target_resolution.scanner_planner_consistent: true
 dry-run plan no longer reports: Drive path does not exist
 physical_write_attempted: false
 bytes_written: 0
 actual_write_enabled: false
 ```
 
-Only after a clean replacement receipt can PR #123 be considered for a separate ready-for-review approval.
+Only after a clean replacement receipt can PR #143 be merged into `usb-creator-foundation-lock`. PR #123 still requires separate future approval to be marked ready, and merging PR #123 into `main` remains a separate final gate.

--- a/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+++ b/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
@@ -1,0 +1,135 @@
+# Phase 5B-4: Windows PHYSICALDRIVE Target Resolution Fix
+
+## Status
+
+Implementation started on branch `fix/windows-physicaldrive-target-resolution`.
+
+This lane is a focused blocker fix for PR #123 hardware-test evidence. It does not authorize marking PR #123 ready, merging `main`, adding physical-write controls, or changing the BootForge USB repository.
+
+## Blocking receipt being addressed
+
+The accepted Windows hardware receipt attached to PR #123 reported:
+
+```text
+Scanner: \\.\PHYSICALDRIVE1 eligible / high confidence
+Dry-run planner: same drive rejected as nonexistent
+Result: FAIL — SAFELY BLOCKED
+```
+
+Safety boundary held during the failed receipt:
+
+```text
+physical_write_attempted: false
+bytes_written: 0
+actual_write_enabled: false
+```
+
+## Fix summary
+
+Phoenix Key now canonicalizes Windows physical-drive target arguments at the desktop bridge boundary before invoking the embedded PhoenixCore dry-run planner.
+
+The bridge normalizes these equivalent target spellings:
+
+```text
+\\.\PHYSICALDRIVE1
+PHYSICALDRIVE1
+physicaldrive1
+\\\\.\\PHYSICALDRIVE1
+```
+
+into the canonical planner argument:
+
+```text
+\\.\PHYSICALDRIVE1
+```
+
+This prevents an over-escaped scanner value from bypassing the existing Python scanner-evidence path and falling into ordinary filesystem path validation.
+
+## Files changed
+
+```text
+apps/phoenix-key/src-tauri/src/main.rs
+docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+```
+
+## Safety boundary
+
+This fix only normalizes a target identifier before dry-run planning.
+
+It does not add:
+
+```text
+physical writing
+raw device writing
+formatting
+partition editing
+mount automation
+unmount automation
+dashboard write controls
+consumer write mode
+```
+
+## Added validation
+
+Rust unit coverage was added for Phoenix Key bridge normalization:
+
+```text
+canonicalizes_standard_windows_physical_drive
+canonicalizes_plain_physical_drive
+canonicalizes_lowercase_physical_drive
+canonicalizes_over_escaped_physical_drive
+leaves_non_physical_drive_target_unchanged
+```
+
+## Required verification before merge
+
+Run from the Phoenix Key app directory:
+
+```text
+cd apps/phoenix-key
+cargo test --manifest-path src-tauri/Cargo.toml
+npm run check:boundaries
+npm run build
+```
+
+Run repository checks:
+
+```text
+black --check --diff . --exclude "node_modules|dist"
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=node_modules,dist
+cd dashboard && npm run lint && npm run build
+```
+
+Run danger scans:
+
+```text
+git grep -n -i -e "diskpart" -e " dd " -e "CreateFile" -e "WriteFile" -e "DeviceIoControl" -e "mkfs" -e "mount" -e "umount" -e "format" -- "*.py" "dashboard/src/App.jsx" "dashboard/vite.config.js"
+
+git grep -n -i -e "Write USB" -e "Burn USB" -e "Flash USB" -e "Start Write" -e "Format USB" -e "Erase Drive" -e "Arm Writer" -e "Execute Write" -e "Destructive Write" -e "Write Now" -- dashboard/src/App.jsx
+```
+
+Expected result:
+
+```text
+no physical writing added
+no dashboard write trigger added
+main untouched
+PR #123 remains draft
+```
+
+## Required hardware retest
+
+After CI passes, run a replacement Windows hardware receipt using the unsigned Phoenix Key preview installer built from this fix branch.
+
+The replacement receipt must prove:
+
+```text
+scanner target: \\.\PHYSICALDRIVE1
+planner target: \\.\PHYSICALDRIVE1
+dry-run plan no longer reports: Drive path does not exist
+physical_write_attempted: false
+bytes_written: 0
+actual_write_enabled: false
+```
+
+Only after a clean replacement receipt can PR #123 be considered for a separate ready-for-review approval.


### PR DESCRIPTION
## Summary

Phase 5B-4 addresses the blocking Windows hardware receipt from PR #123:

```text
Scanner: \\.\PHYSICALDRIVE1 eligible / high confidence
Dry-run planner: same drive rejected as nonexistent
```

The fix resolves Windows physical-drive target values through a dedicated typed Phoenix Key bridge module before invoking the embedded PhoenixCore dry-run planner.

## What changed

- Added `windows_target.rs` as the single Phoenix Key target resolver.
- Canonicalizes standard, plain, lowercase, over-escaped, forward-slash, and leading-zero `PHYSICALDRIVE` forms.
- Rejects embedded markers, invalid suffixes, and empty targets rather than guessing.
- Passes ordinary drive-letter/filesystem targets through unchanged.
- Integrates canonical resolution into `plan_media_build`.
- Adds versioned `phoenix_key.target_resolution.v1` evidence to the returned dry-run JSON:
  - requested path
  - canonical path
  - resolution source
  - typed resolution status
  - target kind
  - whether canonicalization occurred
  - planner root
  - scanner/planner consistency result
- Adds 14 focused Rust tests covering normalization, rejection, passthrough behavior, and plan-evidence integration.
- Updates Phoenix Key CI so Rust tests must pass before MSI/NSIS packaging and artifact upload.
- Expands the Phase 5B-4 evidence document and replacement-hardware-receipt requirements.

## Safety boundary

This PR does **not** add:

- physical writing
- raw device writing
- formatting
- partition editing
- mount or unmount automation
- dashboard write controls
- consumer write mode

It only resolves the target identifier used for dry-run planning and records whether PhoenixCore agreed with that identity.

## Required validation before merge

- Phoenix Key Rust tests/build
- frontend boundary check and build
- repository Black/Flake8 checks
- dashboard lint/build
- danger scans
- replacement Windows hardware receipt proving:
  - scanner target and planner root both equal `\\.\PHYSICALDRIVE1`
  - `target_resolution.schema` equals `phoenix_key.target_resolution.v1`
  - `target_resolution.resolution_status` equals `target_resolved_from_scanner_evidence`
  - `target_resolution.scanner_planner_consistent` is `true`
  - the old `Drive path does not exist` result is gone
  - actual write remains disabled
  - physical write attempted remains false
  - bytes written remain zero

## Promotion boundary

PR #143 remains draft pending CI and replacement Windows hardware validation. PR #123 must remain draft. This PR does not authorize marking PR #123 ready or merging `main`.