### PR TITLE
Phoenix Key: repair Windows physical-drive target resolution

### DIFF
--- a/.github/workflows/phoenix-key-desktop.yml
+++ b/.github/workflows/phoenix-key-desktop.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - run: npm ci
+      - name: Run Phoenix Key Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
       - name: Build Phoenix Key installers
         run: npm run desktop:build
       - name: Inspect and confirm unsigned preview state

--- a/apps/phoenix-key/src-tauri/src/main.rs
+++ b/apps/phoenix-key/src-tauri/src/main.rs
@@ -1,18 +1,22 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod windows_target;
+
 use libbootforge::{scan_devices, DeviceInfo};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{
     ffi::OsStr,
     fs,
     path::{Path, PathBuf},
     process::Command,
 };
+use windows_target::{resolve_target, TargetResolution};
 
 const USB_CREATOR_SOURCE: &str = include_str!("../../../../usb_creator.py");
 const DEVICE_SCANNER_SOURCE: &str = include_str!("../../../../device_scanner.py");
 const SMOKE_RECEIPT_ENV: &str = "PHOENIX_KEY_SMOKE_RECEIPT";
+const TARGET_RESOLUTION_SCHEMA: &str = "phoenix_key.target_resolution.v1";
 
 #[derive(Debug, Serialize)]
 struct SmokeSafetyBoundary {
@@ -152,6 +156,56 @@ fn run_phoenixcore(args: &[&str]) -> Result<Value, String> {
     ))
 }
 
+fn attach_target_resolution(
+    plan: &mut Value,
+    resolution: &TargetResolution,
+) -> Result<(), String> {
+    let planner_root = plan
+        .pointer("/drive_safety/drive/root")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let scanner_planner_consistent = if resolution.is_windows_physical_drive() {
+        planner_root
+            .as_deref()
+            .map(|root| root.eq_ignore_ascii_case(&resolution.canonical_path))
+            .unwrap_or(false)
+    } else {
+        true
+    };
+
+    let resolution_status = if resolution.is_windows_physical_drive() {
+        if scanner_planner_consistent {
+            "target_resolved_from_scanner_evidence"
+        } else {
+            "target_not_resolved_from_scanner_evidence"
+        }
+    } else {
+        "target_passthrough"
+    };
+
+    let object = plan
+        .as_object_mut()
+        .ok_or_else(|| "phoenixcore_plan_not_json_object".to_string())?;
+
+    object.insert(
+        "target_resolution".to_string(),
+        json!({
+            "schema": TARGET_RESOLUTION_SCHEMA,
+            "requested_path": &resolution.requested_path,
+            "canonical_path": &resolution.canonical_path,
+            "resolution_source": resolution.resolution_source,
+            "resolution_status": resolution_status,
+            "target_kind": resolution.target_kind,
+            "canonicalized": resolution.canonicalized,
+            "planner_root": planner_root,
+            "scanner_planner_consistent": scanner_planner_consistent,
+        }),
+    );
+
+    Ok(())
+}
+
 #[tauri::command]
 fn scan_media_targets() -> Result<Value, String> {
     run_phoenixcore(&["--list-json"])
@@ -162,13 +216,19 @@ fn plan_media_build(target_drive: String, image_path: String) -> Result<Value, S
     if target_drive.trim().is_empty() || image_path.trim().is_empty() {
         return Err("target drive and image path are required".to_string());
     }
-    run_phoenixcore(&[
+
+    let target_resolution = resolve_target(&target_drive)?;
+    let normalized_image = image_path.trim().to_string();
+
+    let mut plan = run_phoenixcore(&[
         "--plan-write",
         "--target-drive",
-        &target_drive,
+        &target_resolution.canonical_path,
         "--image",
-        &image_path,
-    ])
+        &normalized_image,
+    ])?;
+    attach_target_resolution(&mut plan, &target_resolution)?;
+    Ok(plan)
 }
 
 fn main() {
@@ -190,7 +250,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::installed_smoke_receipt;
+    use super::{attach_target_resolution, installed_smoke_receipt, resolve_target};
+    use serde_json::json;
 
     #[test]
     fn installed_smoke_receipt_is_read_only_and_non_destructive() {
@@ -208,5 +269,99 @@ mod tests {
             value["safety_boundary"]["browser_hardware_fabrication"],
             "prohibited"
         );
+    }
+
+    #[test]
+    fn records_consistent_scanner_planner_resolution() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!({
+            "drive_safety": {
+                "drive": {
+                    "root": "\\\\.\\PHYSICALDRIVE1"
+                }
+            }
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
+        assert_eq!(
+            plan.pointer("/target_resolution/schema")
+                .and_then(|value| value.as_str()),
+            Some("phoenix_key.target_resolution.v1")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/canonical_path")
+                .and_then(|value| value.as_str()),
+            Some(r"\\.\PHYSICALDRIVE1")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_resolved_from_scanner_evidence")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn records_missing_planner_root_as_inconsistent() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!({
+            "blocked": true,
+            "block_reasons": ["target_not_found_in_scan_evidence"]
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
+        assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_not_resolved_from_scanner_evidence")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(false)
+        );
+        assert!(plan
+            .pointer("/target_resolution/planner_root")
+            .is_some_and(|value| value.is_null()));
+    }
+
+    #[test]
+    fn records_passthrough_target_status() {
+        let resolution = resolve_target("E:\\").unwrap();
+        let mut plan = json!({
+            "drive_safety": {
+                "drive": {
+                    "root": "E:\\"
+                }
+            }
+        });
+
+        attach_target_resolution(&mut plan, &resolution).unwrap();
+
+        assert_eq!(
+            plan.pointer("/target_resolution/resolution_status")
+                .and_then(|value| value.as_str()),
+            Some("target_passthrough")
+        );
+        assert_eq!(
+            plan.pointer("/target_resolution/scanner_planner_consistent")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_plan_payload() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        let mut plan = json!(["unexpected"]);
+
+        let error = attach_target_resolution(&mut plan, &resolution).unwrap_err();
+        assert_eq!(error, "phoenixcore_plan_not_json_object");
     }
 }

--- a/apps/phoenix-key/src-tauri/src/windows_target.rs
+++ b/apps/phoenix-key/src-tauri/src/windows_target.rs
@@ -1,0 +1,138 @@
+use serde::Serialize;
+
+const PHYSICAL_DRIVE_MARKER: &str = "PHYSICALDRIVE";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetResolution {
+    pub requested_path: String,
+    pub canonical_path: String,
+    pub resolution_source: &'static str,
+    pub target_kind: &'static str,
+    pub canonicalized: bool,
+}
+
+impl TargetResolution {
+    pub fn is_windows_physical_drive(&self) -> bool {
+        self.target_kind == "windows_physical_drive"
+    }
+}
+
+pub fn resolve_target(value: &str) -> Result<TargetResolution, String> {
+    let requested_path = value.trim().replace('/', "\\");
+    if requested_path.is_empty() {
+        return Err("target_drive_empty".to_string());
+    }
+
+    let upper = requested_path.to_ascii_uppercase();
+    let Some(marker_index) = upper.find(PHYSICAL_DRIVE_MARKER) else {
+        return Ok(TargetResolution {
+            canonical_path: requested_path.clone(),
+            requested_path,
+            resolution_source: "phoenix_key_bridge_passthrough",
+            target_kind: "filesystem_or_volume_path",
+            canonicalized: false,
+        });
+    };
+
+    let prefix = &upper[..marker_index];
+    let suffix = &upper[marker_index + PHYSICAL_DRIVE_MARKER.len()..];
+    let prefix_without_slashes: String = prefix
+        .chars()
+        .filter(|character| *character != '\\')
+        .collect();
+
+    if !(prefix_without_slashes.is_empty() || prefix_without_slashes == ".") {
+        return Err("invalid_windows_physicaldrive_prefix".to_string());
+    }
+
+    if suffix.is_empty() || !suffix.chars().all(|character| character.is_ascii_digit()) {
+        return Err("invalid_windows_physicaldrive_suffix".to_string());
+    }
+
+    let disk_number = suffix
+        .parse::<u32>()
+        .map_err(|_| "invalid_windows_physicaldrive_number".to_string())?;
+    let canonical_path = format!(r"\\.\PHYSICALDRIVE{disk_number}");
+    let canonicalized = requested_path != canonical_path;
+
+    Ok(TargetResolution {
+        requested_path,
+        canonical_path,
+        resolution_source: "phoenix_key_bridge",
+        target_kind: "windows_physical_drive",
+        canonicalized,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_target;
+
+    #[test]
+    fn canonicalizes_standard_windows_physical_drive() {
+        let resolution = resolve_target(r"\\.\PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(!resolution.canonicalized);
+        assert!(resolution.is_windows_physical_drive());
+    }
+
+    #[test]
+    fn canonicalizes_plain_physical_drive() {
+        let resolution = resolve_target("PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_lowercase_physical_drive() {
+        let resolution = resolve_target("physicaldrive1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_over_escaped_physical_drive() {
+        let resolution = resolve_target(r"\\\\.\\PHYSICALDRIVE1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn canonicalizes_forward_slash_physical_drive() {
+        let resolution = resolve_target("//./physicaldrive1").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+        assert!(resolution.canonicalized);
+    }
+
+    #[test]
+    fn removes_leading_zeroes_from_disk_number() {
+        let resolution = resolve_target("PHYSICALDRIVE001").unwrap();
+        assert_eq!(resolution.canonical_path, r"\\.\PHYSICALDRIVE1");
+    }
+
+    #[test]
+    fn leaves_non_physical_drive_target_unchanged() {
+        let resolution = resolve_target("E:\\").unwrap();
+        assert_eq!(resolution.canonical_path, "E:\\");
+        assert!(!resolution.canonicalized);
+        assert!(!resolution.is_windows_physical_drive());
+    }
+
+    #[test]
+    fn rejects_embedded_physical_drive_marker() {
+        let error = resolve_target(r"C:\temp\PHYSICALDRIVE1").unwrap_err();
+        assert_eq!(error, "invalid_windows_physicaldrive_prefix");
+    }
+
+    #[test]
+    fn rejects_trailing_physical_drive_junk() {
+        let error = resolve_target("PHYSICALDRIVE1.tmp").unwrap_err();
+        assert_eq!(error, "invalid_windows_physicaldrive_suffix");
+    }
+
+    #[test]
+    fn rejects_empty_target() {
+        let error = resolve_target("   ").unwrap_err();
+        assert_eq!(error, "target_drive_empty");
+    }
+}

--- a/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+++ b/docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
@@ -1,0 +1,208 @@
+# Phase 5B-4: Windows PHYSICALDRIVE Target Resolution Fix
+
+## Status
+
+Implementation is active on branch `fix/windows-physicaldrive-target-resolution` in draft PR #143.
+
+This lane is a focused blocker fix for PR #123 hardware-test evidence. It does not authorize marking PR #123 ready, merging `main`, adding physical-write controls, or changing the BootForge USB repository.
+
+## Blocking receipt being addressed
+
+The accepted Windows hardware receipt attached to PR #123 reported:
+
+```text
+Scanner: \\.\PHYSICALDRIVE1 eligible / high confidence
+Dry-run planner: same drive rejected as nonexistent
+Result: FAIL — SAFELY BLOCKED
+```
+
+Safety boundary held during the failed receipt:
+
+```text
+physical_write_attempted: false
+bytes_written: 0
+actual_write_enabled: false
+```
+
+## Fix summary
+
+Phoenix Key now resolves Windows physical-drive target arguments through a dedicated typed resolver before invoking the embedded PhoenixCore dry-run planner.
+
+The resolver accepts these equivalent target spellings:
+
+```text
+\\.\PHYSICALDRIVE1
+PHYSICALDRIVE1
+physicaldrive1
+\\\\.\\PHYSICALDRIVE1
+//./physicaldrive1
+```
+
+and emits the canonical planner argument:
+
+```text
+\\.\PHYSICALDRIVE1
+```
+
+The resolver also:
+
+- removes leading zeroes from a disk number, such as `PHYSICALDRIVE001` to `\\.\PHYSICALDRIVE1`
+- rejects embedded markers such as `C:\temp\PHYSICALDRIVE1`
+- rejects trailing junk such as `PHYSICALDRIVE1.tmp`
+- rejects an empty target
+- passes ordinary drive-letter or filesystem targets through unchanged
+
+This prevents over-escaped or non-canonical scanner values from bypassing the existing Python scanner-evidence path and falling into ordinary filesystem path validation.
+
+## Integration behavior
+
+`plan_media_build` now:
+
+1. resolves the selected target through `windows_target::resolve_target`
+2. passes the canonical target to the embedded PhoenixCore `--plan-write` command
+3. records target-resolution evidence in the returned JSON plan
+
+The added `target_resolution` object contains:
+
+```text
+requested_path
+canonical_path
+resolution_source
+target_kind
+canonicalized
+planner_root
+scanner_planner_consistent
+```
+
+For the receipt scenario, expected evidence is:
+
+```json
+{
+  "requested_path": "PHYSICALDRIVE1",
+  "canonical_path": "\\\\.\\PHYSICALDRIVE1",
+  "resolution_source": "phoenix_key_bridge",
+  "target_kind": "windows_physical_drive",
+  "canonicalized": true,
+  "planner_root": "\\\\.\\PHYSICALDRIVE1",
+  "scanner_planner_consistent": true
+}
+```
+
+If PhoenixCore does not return a matching planner root, the plan remains visible but `scanner_planner_consistent` is recorded as `false`. The bridge does not guess, substitute a different disk, or enable writing.
+
+## Files changed
+
+```text
+.github/workflows/phoenix-key-desktop.yml
+apps/phoenix-key/src-tauri/src/main.rs
+apps/phoenix-key/src-tauri/src/windows_target.rs
+docs/evidence/phase5b4-windows-physicaldrive-target-resolution.md
+```
+
+## Safety boundary
+
+This fix only resolves and records a target identifier before dry-run planning.
+
+It does not add:
+
+```text
+physical writing
+raw device writing
+formatting
+partition editing
+mount automation
+unmount automation
+dashboard write controls
+consumer write mode
+```
+
+Existing safety claims remain:
+
+```text
+actual_write_enabled: false
+physical_write_attempted: false
+bytes_written: 0
+dashboard write path: absent
+```
+
+## Added validation
+
+Rust unit coverage now includes:
+
+```text
+canonicalizes_standard_windows_physical_drive
+canonicalizes_plain_physical_drive
+canonicalizes_lowercase_physical_drive
+canonicalizes_over_escaped_physical_drive
+canonicalizes_forward_slash_physical_drive
+removes_leading_zeroes_from_disk_number
+leaves_non_physical_drive_target_unchanged
+rejects_embedded_physical_drive_marker
+rejects_trailing_physical_drive_junk
+rejects_empty_target
+records_consistent_scanner_planner_resolution
+records_missing_planner_root_as_inconsistent
+rejects_non_object_plan_payload
+```
+
+The Phoenix Key Windows workflow now runs:
+
+```text
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+before building MSI and NSIS preview installers. A failed Rust unit test blocks installer packaging and artifact upload.
+
+## Required verification before merge
+
+Run from the Phoenix Key app directory:
+
+```text
+cd apps/phoenix-key
+cargo test --manifest-path src-tauri/Cargo.toml
+npm run check:boundaries
+npm run build
+```
+
+Run repository checks:
+
+```text
+black --check --diff . --exclude "node_modules|dist"
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=node_modules,dist
+cd dashboard && npm run lint && npm run build
+```
+
+Run danger scans:
+
+```text
+git grep -n -i -e "diskpart" -e " dd " -e "CreateFile" -e "WriteFile" -e "DeviceIoControl" -e "mkfs" -e "mount" -e "umount" -e "format" -- "*.py" "dashboard/src/App.jsx" "dashboard/vite.config.js"
+
+git grep -n -i -e "Write USB" -e "Burn USB" -e "Flash USB" -e "Start Write" -e "Format USB" -e "Erase Drive" -e "Arm Writer" -e "Execute Write" -e "Destructive Write" -e "Write Now" -- dashboard/src/App.jsx
+```
+
+Expected result:
+
+```text
+no physical writing added
+no dashboard write trigger added
+main untouched
+PR #123 remains draft
+```
+
+## Required hardware retest
+
+After CI passes, run a replacement Windows hardware receipt using the unsigned Phoenix Key preview installer built from PR #143.
+
+The replacement receipt must prove:
+
+```text
+scanner target: \\.\PHYSICALDRIVE1
+planner target: \\.\PHYSICALDRIVE1
+target_resolution.scanner_planner_consistent: true
+dry-run plan no longer reports: Drive path does not exist
+physical_write_attempted: false
+bytes_written: 0
+actual_write_enabled: false
+```
+
+Only after a clean replacement receipt can PR #143 be merged into `usb-creator-foundation-lock`. PR #123 still requires separate future approval to be marked ready, and merging PR #123 into `main` remains a separate final gate.


### PR DESCRIPTION
## Summary

Clean reconstruction of PR #143 directly on current `main`.

- preserves the installed-executable smoke receipt and 30-day artifact attestation already on `main`
- adds the typed Windows `PHYSICALDRIVE` resolver and target-resolution evidence
- adds focused Rust coverage for normalization, rejection, passthrough, and scanner/planner consistency
- requires Rust tests before MSI/NSIS packaging
- preserves the read-only boundary: no writing, formatting, partitioning, mounting, or dashboard write controls

## Required gates

- Phoenix Key frontend boundary, receipt, and production build
- Phoenix Key Rust tests and Windows installer build
- repository Python/dashboard/danger checks
- replacement Windows hardware receipt proving scanner/planner identity consistency and zero bytes written

Supersedes the conflicted historical branch in PR #143. Keep draft until exact-head CI and physical Windows dry-run evidence pass.